### PR TITLE
Resync against anchor HEAD, add conflux start, and fix CONFLUX_DIR isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ commands handed straight to `anchorctl`.
 **That's the whole setup.** A reboot needs nothing typed: the service is registered
 and enabled, the credential renews itself, and the machine comes back at the same
 overlay address. `conflux down` stops the anchor now and leaves the service and
-configuration in place; `conflux uninstall` removes them.
+configuration in place, `conflux start` brings it back before the next reboot, and
+`conflux uninstall` removes them.
 
 ### Reverse proxy: publish a service without an interface
 
@@ -224,6 +225,7 @@ reaches the realm over — the host's IP network by default, or a link named by
 | `conflux up [--taint T] [--ipv4 PREFIX \| --no-ipv4] [--subnet CIDR]... [--uplink DEV \| --no-uplink] [--peers HOST:PORT]` | enrol if needed, start in TUN mode, register the boot service |
 | `conflux proxy PORT[/NETWORK]=BACKEND ... [--taint T] [--uplink DEV] [--peers HOST:PORT]` | enrol if needed, start in userspace mode serving those backends |
 | `conflux down` | stop the anchor now; the boot service and the configuration stay |
+| `conflux start` | start it again now, from the configuration already on disk |
 | `conflux renew` | fetch a fresh credential and install it on the running anchor, hot |
 | `conflux status` | conflux's state, and `anchorctl status` beneath it |
 | `conflux install` | register the boot service; start it if a configuration exists |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -219,8 +219,13 @@ non-interactive run without `--yes` refuses rather than destroy an identity sile
 
 ## `conflux status`
 
-conflux's state — service, mode, taint, AnchorID, credential expiry, API — and then
-`anchorctl status` beneath it. Exits 78 when the machine has no configuration.
+conflux's state — service, mode, exit, taint, AnchorID, credential expiry, API, and
+the uplink reopen tally if there is one — and then `anchorctl status` beneath it.
+Exits 78 when the machine has no configuration.
+
+The `exit` line appears only when this machine is an exit one way or the other.
+conflux goes to some trouble not to become one by accident, so a machine that *is*
+one should not need a config file read to find out.
 
 ## `conflux version`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,21 +1,22 @@
 # Commands
 
-conflux keeps eight names for itself. Every other argument vector is handed to the
+conflux keeps nine names for itself. Every other argument vector is handed to the
 embedded `anchorctl` unchanged — not parsed, not rewritten, not validated.
 
 ## The split
 
-conflux's: `up`, `proxy`, `down`, `install`, `uninstall`, `status`, `version`, `help`,
-plus `anchorctl` as an escape hatch and a hidden `serve` the boot service runs.
+conflux's: `up`, `proxy`, `start`, `down`, `install`, `uninstall`, `renew`, `status`,
+`version`, `help`, plus `anchorctl` as an escape hatch and a hidden `serve` the boot
+service runs.
 
 anchorctl's, reached by typing them: `peers`, `route`, `routes`, `connect`, `punch`,
 `events`, `metrics`, `export`, `children`, `telemetry`, `send`, `subscribe`, `keygen`,
 `issue`, `delegate`, `renew-link`, `install-link`, `id`, `inspect`, `config`, `renew`,
 `mint-realm`, `mint-anchor`.
 
-### The four collisions
+### The five collisions
 
-`proxy`, `renew`, `status` and `help` exist on both sides. Each is resolved
+`start`, `proxy`, `renew`, `status` and `help` exist on both sides. Each is resolved
 explicitly.
 
 **`help`** is conflux's, always. It prints conflux's usage and then anchorctl's whole
@@ -39,16 +40,22 @@ takes `-cred FILE` and installs one the caller already holds. So any flag reachi
 `conflux renew` other than `-h` names anchorctl's, and is answered with the escape
 hatch rather than guessed at.
 
-**`start`, `stop` and `restart`** are anchorctl's and conflux refuses to pass them
-through. Running them directly would build an anchor conflux's configuration does not
-describe, or stop one conflux believes is running, and the next reboot would silently
-disagree. The refusal names `up` and `down` and the escape hatch.
+**`start`** is resolved by shape, like `renew`. conflux's takes no arguments at all:
+it starts the anchor this machine is already configured for. anchorctl's builds one
+from arguments the caller supplies. So any flag reaching `conflux start` other than
+`-h` names anchorctl's, and is answered with the escape hatch rather than guessed at.
+
+**`stop` and `restart`** are anchorctl's and conflux refuses to pass them through.
+Running them directly would stop an anchor conflux believes is running, or build one
+its configuration does not describe, and the next reboot would silently disagree. The
+refusal names `down` and `start` and the escape hatch.
 
 ## `conflux up`
 
 ```
 conflux up [--taint T]... [--ipv4 PREFIX | --no-ipv4] [--subnet CIDR]... [--interface NAME]
            [--uplink DEV | --no-uplink] [--peers HOST:PORT]... [--no-peers] [--api URL]
+           [--port N | --no-port] [--low-latency] [--serve-exit] [--use-exit]
 ```
 
 Enrols this machine if it has never been, starts an anchor in TUN mode, writes the
@@ -67,6 +74,24 @@ configuration, and registers the boot service.
 | `--peers HOST:PORT` | where to start looking for the realm; repeat for more. `anchorxxx@host:port` also works. Enrolment supplies this, so it is an override — see below. |
 | `--no-peers` | forget an override and go back to the list enrolment supplies. |
 | `--api URL` | the enrolment API base. Default `https://api.veilnet.com.au`. |
+| `--port N` | the UDP port to bind, 1–65535. Omit it and the kernel picks one. |
+| `--no-port` | go back to letting the kernel pick. |
+| `--low-latency` | carry frames on QUIC datagrams: no head-of-line blocking between flows to one peer, and a lost frame stays lost rather than holding up the ones behind it. |
+| `--no-low-latency` | go back to carrying frames on streams. |
+| `--serve-exit` | offer this machine as a way out to the public internet. |
+| `--use-exit` | send this machine's own internet traffic over the overlay. |
+| `--no-serve-exit`, `--no-use-exit` | the way back from either. |
+
+An anchor listens on **every** interface, so `--port` is a port and not an address:
+the host's addresses change underneath it, and pinning one is a promise the host
+cannot keep. Name a port to write a firewall rule or a port-forward against; leave it
+alone otherwise. It is refused beside `--uplink`, which binds no socket at all.
+
+Both exits need a host interface, so both are `up`'s and not `proxy`'s. Neither is
+ever inherited from the enrolment manifest: conflux passes both in whichever
+direction they were set, because an anchor that became an internet exit because a
+document said so is the worst kind of surprise. Switching a machine to `proxy` clears
+them.
 
 `--uplink` is the medium and the verb is the mode, so the flag means the same thing
 on `proxy`, and neither answer constrains the other. A malformed spec, and the `fd:N`
@@ -93,10 +118,15 @@ Needs root.
 ```
 conflux proxy PORT[/NETWORK]=BACKEND ... [--taint T]... [--uplink DEV | --no-uplink]
               [--peers HOST:PORT]... [--no-peers] [--api URL]
+              [--port N | --no-port] [--low-latency]
 ```
 
-Starts in userspace mode serving those backends. Same taint, uplink and API flags as
-`up`. Specs and flags may be written in either order.
+Starts in userspace mode serving those backends. Same taint, uplink, peers, API,
+`--port` and `--low-latency` flags as `up`. Specs and flags may be written in either
+order.
+
+`--serve-exit` and `--use-exit` are not here: routing the public internet either way
+needs a host interface, which userspace mode has none of.
 
 The grammar is `OVERLAYPORT[/NETWORK]=BACKEND`: the network defaults to `tcp` and must
 be `tcp` or `udp`, the port is 1–65535, and a duplicate overlay port is refused rather
@@ -105,12 +135,42 @@ than silently keeping the last. See [modes.md](modes.md) for the spec table, and
 
 Needs root, only to register the boot service.
 
+## `conflux start`
+
+```
+conflux start
+```
+
+Starts the anchor now, from the configuration already on disk, in whichever mode it
+names. Takes no arguments: it decides nothing, enrols nothing, and invents no
+configuration.
+
+The counterpart to `down`, and the reason it exists. `down` deliberately leaves the
+boot registration and the configuration in place, so there has to be a word for
+"bring that back now" that is not a reboot. That word used to be `conflux install`,
+whose name and usage line both say *register the boot service* — it started one as a
+side effect, and pointing an operator at it was papering over a missing verb.
+
+It is mode-agnostic on purpose. `up` would do for a TUN machine, but `up` is not a
+resume: it re-decides the configuration, and on a userspace machine it changes the
+mode and drops the proxies. A machine serving eight ports cannot be brought back by
+retyping eight specs correctly from memory.
+
+| Situation | |
+|---|---|
+| not installed | exit 69, naming `install`, `up` and `proxy` — there is no service to start |
+| installed, no configuration | exit 78, naming `up` and `proxy` — there is nothing to start |
+| already running | restarts it. A `start` that refused would be answering a question nobody asked |
+
+Needs root.
+
 ## `conflux down`
 
 Stops the anchor now. The boot service stays registered and the configuration and
-identity stay on disk, so the next reboot brings the machine back exactly as it was.
-Refuses with exit 69 if conflux is not installed, because there would be nothing for a
-reboot to bring back and the word would be a lie.
+identity stay on disk, so the next reboot brings the machine back exactly as it was,
+and `conflux start` brings it back before then. Refuses with exit 69 if conflux is not
+installed, because there would be nothing for a reboot to bring back and the word
+would be a lie.
 
 ## `conflux install`
 
@@ -120,6 +180,10 @@ configuration is invented.
 
 `up` and `proxy` call it internally after writing their configuration, so there is one
 path for "register and run" and one for "configure, persist, then register and run".
+
+Registration is the point here. To start a machine that is already registered, that is
+`conflux start` — the two share the starting, so neither can drift into starting a
+different anchor from the other.
 
 ## `conflux renew`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -259,7 +259,7 @@ explanations of every other refusal — passes through untouched.
 
 | Variable | Effect |
 |---|---|
-| `CONFLUX_DIR` | roots every conflux path in one directory. What the tests use. |
+| `CONFLUX_DIR` | roots a whole separate conflux installation in one directory — config, identity, socket and the boot service, which is named after the root so it cannot replace the machine's own. What the tests use. See [testing.md](testing.md). |
 | `CONFLUX_DEBUG=1` | pass `-v` to anchord. |
 | `CONFLUX_ALLOW_INSECURE_API=1` | permit a plain-http API base. For tests only. |
 | `ANCHOR_SOCKET`, `ANCHORD_TOKEN` | if already set, conflux leaves them alone and pass-through uses yours. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ under a systemd unit with `User=` or `ProtectHome=`.
 | state, identity, binaries | `/var/lib/conflux/` | `/Library/Application Support/conflux/` | `%ProgramData%\conflux\` | `/var/db/conflux/` |
 | socket and token | `/run/conflux/` | `/var/run/conflux/` | `%ProgramData%\conflux\run\` | `/var/run/conflux/` |
 
-`CONFLUX_DIR` roots all of them in one directory.
+`CONFLUX_DIR` roots all of them in one directory, and the boot service with them — it is named after the root, so a run under it is a separate installation rather than a replacement for the machine's own. See [testing.md](testing.md).
 
 Every directory is `0700` and every file `0600`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,6 +30,10 @@ Every directory is `0700` and every file `0600`.
   "subnets": ["192.168.1.0/24"],
   "uplink": "/dev/ttyUSB0:115200",
   "peers": ["genesis.veilnet.com.au:4700"],
+  "port": 4711,
+  "lowLatency": false,
+  "serveExit": false,
+  "useExit": false,
   "tunName": "anchor0",
   "apiBaseUrl": "https://api.veilnet.com.au",
   "createdAt": "2026-09-06T06:35:41Z",
@@ -46,12 +50,15 @@ Every directory is `0700` and every file `0600`.
 | `proxies` | `PORT[/NETWORK]=BACKEND` specs. `proxy` only. |
 | `uplink` | a device, with an optional line speed. Absent means the host's IP network, which is the usual case. Either mode. See [uplink.md](uplink.md). |
 | `peers` | bootstrap entries, `host:port` or `anchorxxx@host:port`. **Absent is the usual case and not a missing setting:** anchorctl takes the list from the enrolment manifest for exactly the fields no flag named, so an empty `peers` is what keeps the issuer's own nodes in play. Present, it overrides them. |
+| `port` | the UDP port to bind on every interface. Absent means the kernel picks one, which is the usual case. A port and not an address: an anchor listens everywhere, and the host's addresses change under it. Refused beside `uplink`, which binds no socket. |
+| `lowLatency` | carry layer-2 frames on QUIC datagrams instead of streams. Absent is false. Either mode. |
+| `serveExit`, `useExit` | route the public internet out of and into the overlay. Absent is false, and both are `tun` only — switching a machine to `proxy` clears them. |
 | `apiBaseUrl` | absent means the default. |
 
 This file is the whole of what a reboot needs. Every `up` and every `proxy` rewrites
 it, so it is always the current desired state.
 
-Editing it by hand is supported; `conflux install` restarts from whatever it says, and
+Editing it by hand is supported; `conflux start` restarts from whatever it says, and
 anything anchor would refuse is refused by conflux first, naming the field.
 
 ## `manifest.b64` — the identity
@@ -82,9 +89,15 @@ nothing on the server, and the response was the only one. See
   "notAfter": "2026-09-13T06:35:43.871Z",
   "renewalUrl": "https://api.veilnet.com.au/ghosts/alpha/renew",
   "enrolledAt": "2026-09-06T06:35:43.559Z",
-  "binSetId": "998ece52739a7c74"
+  "binSetId": "998ece52739a7c74",
+  "linkReopens": 2,
+  "lastLinkReopen": "2026-09-08T11:04:12Z"
 }
 ```
+
+`linkReopens` and `lastLinkReopen` count an uplink found dead and rebuilt, and are
+here rather than in memory because the supervisor that does the reopening and the
+`conflux status` that reports it are different processes. See [uplink.md](uplink.md).
 
 Everything here is derived. Delete it and the next start re-learns the AnchorID and
 the credential window at the cost of one extra call. That is why it is a separate file
@@ -133,11 +146,11 @@ control, inheritance off — before writing anything into them.
 
 ## What survives what
 
-| | `conflux down` | `conflux install` | `conflux uninstall` |
-|---|---|---|---|
-| running anchor | stopped | (re)started | stopped |
-| boot service | kept | registered | removed |
-| `conflux.json` | kept | kept | deleted |
-| `manifest.b64` | kept | kept | **deleted, permanently** |
-| `state.json` | kept | kept | deleted |
+| | `conflux down` | `conflux start` | `conflux install` | `conflux uninstall` |
+|---|---|---|---|---|
+| running anchor | stopped | (re)started | (re)started | stopped |
+| boot service | kept | kept | registered | removed |
+| `conflux.json` | kept | kept | kept | deleted |
+| `manifest.b64` | kept | kept | kept | **deleted, permanently** |
+| `state.json` | kept | kept | kept | deleted |
 | extracted binaries | kept | kept | deleted |

--- a/docs/install.md
+++ b/docs/install.md
@@ -67,17 +67,17 @@ Replace the binary and re-register:
 
 ```console
 $ sudo install -m 0755 conflux-linux-amd64 /usr/local/bin/conflux
-$ sudo conflux install
+$ sudo conflux start
 ```
 
 The new binary carries a different anchor pair, which extracts into its own directory
-rather than over the one the running daemon has open, and `conflux install` restarts
-the service onto it. Nothing is re-enrolled and the identity is untouched.
+rather than over the one the running daemon has open, and `conflux start` restarts the
+service onto it. Nothing is re-enrolled and the identity is untouched.
 
-Until you run `conflux install`, `conflux status` reports:
+Until you run `conflux start`, `conflux status` reports:
 
 ```
-  binaries     stale — conflux was upgraded; run "conflux install" to restart onto the new anchor
+  binaries     stale — conflux was upgraded; run "conflux start" to restart onto the new anchor
 ```
 
 ## Removing

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -19,6 +19,25 @@ and the BSDs, Administrator and `wintun.dll` on Windows.
 Because the kernel owns the address, a service published on the overlay is an ordinary
 `bind` — there is no proxy to configure and conflux offers none.
 
+### Exits
+
+An interface is also what makes an exit possible, so both exit flags are `up`'s:
+
+```console
+$ sudo conflux up --serve-exit      # be a way out to the public internet for the realm
+$ sudo conflux up --use-exit        # send this machine's own internet over the overlay
+```
+
+They are independent — a machine can do either, both or neither — and both are off
+unless asked for. conflux passes them explicitly in whichever direction they were set
+rather than letting the enrolment manifest supply them, because an anchor that became
+an internet exit because a document said so is the worst kind of surprise. `--no-serve-exit`
+and `--no-use-exit` are the way back.
+
+Routing traffic out needs the host to be willing to forward it; see
+[`--subnet`, and what the host has to be](#--subnet-and-what-the-host-has-to-be),
+which has the same requirement for the same reason.
+
 ## Userspace — `conflux proxy`
 
 The overlay lives entirely inside the daemon, in a userspace network stack. Nothing on
@@ -35,6 +54,10 @@ does not resolve yet is legitimate.
 
 conflux still needs root to *register the boot service* — a proxy that vanishes on the
 next reboot is not what anyone asked for — but the anchor itself needs nothing.
+
+Neither exit is available here: routing the public internet either way needs a host
+interface, and userspace mode has none. `conflux proxy` does not register the flags at
+all, rather than accepting them and refusing later.
 
 ## Why they cannot be combined
 
@@ -65,7 +88,11 @@ conflux: this machine was running in TUN mode with interface anchor0.
   a host interface cannot also serve a reverse proxy …
 ```
 
-The identity does not change. Only the mode does.
+The identity does not change. Only the mode does — along with the settings that
+cannot survive it. Switching to userspace clears the overlay IPv4, the subnets and
+both exits, because each needs a host interface; switching to TUN clears the proxy
+specs. Everything that is orthogonal to the mode — the taints, the uplink, the peers,
+the port, low latency — is kept.
 
 ## Proxy specs
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -35,6 +35,18 @@ anchor says goodbye, then signal the process, then kill it. The second step is t
 important one — an announced departure saves every peer from working it out by
 timeout — and killing is only safe because it has already happened.
 
+## One machine, one service — unless CONFLUX_DIR says otherwise
+
+The unit, the launchd label and the SCM entry are all named `conflux`, one per
+machine, which is what "one configuration per machine" means in practice.
+
+A run under `CONFLUX_DIR` is the exception, because it is a separate installation and
+not the machine's own: the service takes a suffix derived from the root
+(`conflux-44a6e4f4.service`), and the root is written into the argv it is registered
+with, so the supervisor comes back to the same directory at boot. Neither happens
+without `CONFLUX_DIR`, so an ordinary install is byte-for-byte what it always was.
+See [testing.md](testing.md).
+
 ## The four verbs, and which pair is which
 
 Two pairs that are easy to confuse, because both look like they turn something off:

--- a/docs/service.md
+++ b/docs/service.md
@@ -10,6 +10,7 @@ systemd / launchd / SCM
   └── conflux serve
         ├── anchord -socket … -token-file …
         ├── the renewal timer
+        ├── the link watcher, on a machine configured for an uplink
         └── the restart loop
 ```
 
@@ -33,6 +34,23 @@ Shutdown runs in one order everywhere: stop the renewal timer, `anchorctl stop` 
 anchor says goodbye, then signal the process, then kill it. The second step is the
 important one — an announced departure saves every peer from working it out by
 timeout — and killing is only safe because it has already happened.
+
+## The four verbs, and which pair is which
+
+Two pairs that are easy to confuse, because both look like they turn something off:
+
+| | Pair | What it touches |
+|---|---|---|
+| now | `conflux start` / `conflux down` | the running anchor. The registration and the configuration are untouched, so a reboot behaves the same either way. |
+| permanently | `conflux install` / `conflux uninstall` | the boot registration. `uninstall` also deletes the configuration and the identity. |
+
+`down` then `start` is the restart. `install` happens to start a configured machine as
+well, which is why it used to be what `down` pointed at, but registration is its
+subject and starting is a side effect — `start` is the verb whose subject is starting.
+
+Neither `up` nor `proxy` belongs in that table: they decide the configuration and then
+do both. `start` decides nothing, which is exactly what makes it the way back from
+`down` on a userspace machine, where `up` would change the mode and drop the proxies.
 
 ## systemd
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,14 +19,14 @@ a daemon or a network. Most of conflux can be.
 | Package | What is asserted |
 |---|---|
 | `anchor` | the embedded binaries are real executables of the right architecture, and `SetID` is stable |
-| `internal/config` | JSON round-trips; the mode rule matches anchor's; proxy specs, IPv4 prefixes and taint names parse and refuse exactly as anchor does; atomic writes leave old-or-new and never a truncated file, and narrow a file that was `0644` |
+| `internal/config` | JSON round-trips, the tuning fields included; the mode rule matches anchor's; an exit needs a host interface and a port is refused beside an uplink; proxy specs, IPv4 prefixes and taint names parse and refuse exactly as anchor does; atomic writes leave old-or-new and never a truncated file, and narrow a file that was `0644` |
 | `internal/enrol` | the manifest decodes, refuses a realm manifest and a future format version, and **survives a renewal losslessly** |
 | `internal/enrol` (client) | against `httptest`: the happy path, malformed base64, 4xx and 5xx, an oversized body, a cross-host renewal URL, a plain-http base, cancellation, and clock skew |
 | `internal/taint` | generated names satisfy anchor's rule, avoid ambiguous glyphs, and do not repeat |
-| `internal/daemon` | the renewal arithmetic: two thirds of the *observed* window, expiry, absent timestamps, and the clamp |
-| `internal/anchorctl` | the argv goldens, that every flag they use exists, and the output parsers |
+| `internal/daemon` | the renewal arithmetic: two thirds of the *observed* window, expiry, absent timestamps, and the clamp; and the link watcher's device parsing and its grace against anchor's own dial timeout |
+| `internal/anchorctl` | the argv goldens, that every flag they use exists, and the output parsers, including the metrics gauge the link watcher reads |
 | `internal/libexec` | extraction, idempotence, eight concurrent callers, and repair of a truncated set |
-| `internal/cli` | the collision rules, and that nothing shadows anchorctl unintentionally |
+| `internal/cli` | the collision rules — `start` and `renew` by shape, `proxy` and `status` by arity — and that nothing shadows anchorctl unintentionally |
 
 ## The three tests worth knowing about
 
@@ -96,9 +96,29 @@ $ sudo CONFLUX_DIR=/tmp/cfx-test conflux up --peers genesis.veilnet.com.au:4700
 $ sudo CONFLUX_DIR=/tmp/cfx-test conflux status     # peers > 0, up=yes
 ```
 
-`CONFLUX_DIR` keeps the whole run — config, identity, socket — out of `/etc/conflux`
-and `/var/lib/conflux`, so it cannot disturb a real machine. Port 4700 is UDP; a TCP
-probe of it is refused, and that is expected rather than a fault.
+`CONFLUX_DIR` keeps the config, the identity, the state and the socket out of
+`/etc/conflux` and `/var/lib/conflux`. Port 4700 is UDP; a TCP probe of it is refused,
+and that is expected rather than a fault.
+
+> **`CONFLUX_DIR` does not isolate the boot service.** `unitPath` is a constant —
+> `/etc/systemd/system/conflux.service`, and the launchd and SCM equivalents are
+> constants too — and the service package never reads `CONFLUX_DIR`. So `up` and
+> `proxy` under it still rewrite that one unit and restart it, because both call
+> `install` on their way through.
+>
+> On a machine that is already a conflux node, that replaces the running node with the
+> dev build. Do this in the systemd container above, or on a machine that is not one,
+> or `conflux down` and note the `ExecStart` first so it can be put back. There is no
+> flag that makes the registration temporary, and inventing one to make a test tidier
+> would be a boot-time behaviour nobody asked for.
+
+To check reachability *without* touching the service, drive the embedded anchorctl
+directly against a daemon you start yourself — that is what the escape hatch is for,
+and it registers nothing:
+
+```console
+$ conflux anchorctl start -peers genesis.veilnet.com.au:4700 -identity … -root … -cred …
+```
 
 Two things worth checking deliberately, because neither is obvious from a passing run:
 
@@ -118,11 +138,12 @@ Two things worth checking deliberately, because neither is obvious from a passin
 - **macOS TUN under a LaunchDaemon.** CI can build and test on macOS, but not open a
   utun from a system daemon.
 - **The Windows service's recovery actions.**
-- **A real uplink.** What is covered here is the spec parser, the argv, and the
-  refusals — the `fd:N` form conflux's supervisor cannot hand over, and Windows, where
-  anchor has no way to open a link. Nothing in this tree opens a device or a
-  pseudo-terminal: the link itself is anchor's to test, and it does, over a real pty.
-  Two machines on a cable have no runner.
+- **A real uplink.** What is covered here is the spec parser, the argv, the refusals
+  — the `fd:N` form conflux's supervisor cannot hand over, and Windows, where anchor
+  has no way to open a link — and the link watcher's decision function against
+  synthetic inputs. Nothing in this tree opens a device or a pseudo-terminal: the link
+  itself is anchor's to test, and it does, over a real pty. Two machines on a cable
+  have no runner, so the watcher's *reopen* path is reasoned about rather than run.
 - **The boot service and the two-node integration test, in CI.** Both need the real
   anchor binaries, which are not in git and which a runner has no way to fetch, so
   both are `workflow_dispatch` only. They are run locally: `./test/integration.sh`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -92,33 +92,45 @@ enrolment manifest, which is what lets the API move a node without touching a si
 machine. Point a dev build at it explicitly:
 
 ```console
-$ sudo CONFLUX_DIR=/tmp/cfx-test conflux up --peers genesis.veilnet.com.au:4700
-$ sudo CONFLUX_DIR=/tmp/cfx-test conflux status     # peers > 0, up=yes
+$ sudo CONFLUX_DIR=/var/lib/cfx-dev conflux up --peers genesis.veilnet.com.au:4700 \
+      --interface anchor1
+$ sudo CONFLUX_DIR=/var/lib/cfx-dev conflux status  # peers > 0, up=yes
 ```
 
-`CONFLUX_DIR` keeps the config, the identity, the state and the socket out of
-`/etc/conflux` and `/var/lib/conflux`. Port 4700 is UDP; a TCP probe of it is refused,
-and that is expected rather than a fault.
+`CONFLUX_DIR` roots the whole installation somewhere else — the config, the identity,
+the state, the socket, **and the boot service**. Port 4700 is UDP; a TCP probe of it is
+refused, and that is expected rather than a fault.
 
-> **`CONFLUX_DIR` does not isolate the boot service.** `unitPath` is a constant —
-> `/etc/systemd/system/conflux.service`, and the launchd and SCM equivalents are
-> constants too — and the service package never reads `CONFLUX_DIR`. So `up` and
-> `proxy` under it still rewrite that one unit and restart it, because both call
-> `install` on their way through.
->
-> On a machine that is already a conflux node, that replaces the running node with the
-> dev build. Do this in the systemd container above, or on a machine that is not one,
-> or `conflux down` and note the `ExecStart` first so it can be put back. There is no
-> flag that makes the registration temporary, and inventing one to make a test tidier
-> would be a boot-time behaviour nobody asked for.
+The service is included because it has to be. A run rooted elsewhere is a separate
+installation of conflux, not the machine's own, so:
 
-To check reachability *without* touching the service, drive the embedded anchorctl
-directly against a daemon you start yourself — that is what the escape hatch is for,
-and it registers nothing:
+- the service is named after the root — `conflux-e7616592.service`,
+  `org.veilnet.conflux-e7616592`, or the same SCM entry — and cannot be registered
+  over a real node's;
+- the root is written into the argv the service is registered with, because none of
+  the three service managers carries the operator's environment into what it starts.
+  Without that the unit came back at boot reading `/etc/conflux`, and the CLI waited
+  out its ninety seconds for a socket that was never going to appear.
+
+So a dev run and a real node coexist on one machine:
 
 ```console
-$ conflux anchorctl start -peers genesis.veilnet.com.au:4700 -identity … -root … -cred …
+$ conflux status                                    # the machine's own
+  service      active (systemd: conflux.service, enabled at boot)
+$ CONFLUX_DIR=/var/lib/cfx-dev conflux status       # the dev one
+  service      active (systemd: conflux-e7616592.service, enabled at boot)
 ```
+
+**They still share the interface name.** Both default to `anchor0`, and the second to
+start gets `device or resource busy` — pass `--interface anchor1` to the dev one, as
+above. That is the one thing `CONFLUX_DIR` does not name, because an interface belongs
+to the host and not to a conflux installation. The failure is treated as permanent
+rather than retried to the unit's ninety-second timeout, so it arrives in a few
+seconds and says what it is.
+
+**Not `/tmp`.** systemd clears it on boot, so a dev root there is gone by the time the
+service starts and the unit exits 78 — correctly, but it makes the reboot test
+meaningless. Anywhere persistent will do.
 
 Two things worth checking deliberately, because neither is obvious from a passing run:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@ beneath it, and most of what follows is a way of reading that output.
 
 | Symptom | Cause | What to do |
 |---|---|---|
-| `nothing is running here` | no daemon on the socket | `conflux up`, `conflux proxy`, or `conflux install` if a configuration already exists |
+| `nothing is running here` | no daemon on the socket | `conflux start` if a configuration already exists, otherwise `conflux up` or `conflux proxy` |
 | `this needs root` | every state-changing verb needs it | `sudo conflux …` |
 | `status` exits 78 | never configured | `conflux up` or `conflux proxy` |
 | `up` exits 2 with "needs `--ipv4` or `--no-ipv4`" | no terminal to prompt at | pass one of them; that is what they are for |
@@ -50,8 +50,23 @@ enrolled yet`. Bring it up once where it has the internet.
 permanently on a cable stops being admitted after seven days; `conflux status` says
 `credential EXPIRED`.
 
-**An unplugged adapter needs a restart.** A device is not reopened, so a link that
-ended stays ended: `sudo conflux up` restarts it from the configuration.
+**A link that ended is reopened for you.** A device is not reopened by anchor, so
+conflux watches it: a device that leaves the filesystem is acted on at once, and a
+link carrying nothing for 90 seconds is treated as ended. Either way the anchor is
+rebuilt on it. `conflux status` shows the tally, which is the thing to look at when a
+machine seems fine but keeps losing peers:
+
+```console
+$ conflux status
+  uplink    7 reopens, last 2026-09-08T11:04:12Z
+```
+
+Seven reopens is a cable, a connector or a far end at fault — conflux is papering over
+it, not fixing it. If it is reopening and never staying up, check the far end is
+running at all: an idle link whose far end is switched off is indistinguishable from a
+dead one, and gets restarted on the same 90-second grace.
+
+To force one by hand: `sudo conflux start`.
 
 ## Two machines are up and cannot reach each other
 

--- a/docs/uplink.md
+++ b/docs/uplink.md
@@ -121,13 +121,15 @@ leaves a deployment behaving unlike its own configuration file:
 | Setting | Refused because |
 |---|---|
 | a listen address | the link is the medium; no socket is bound, so an address names nothing |
+| a port | the same reason: `conflux up --uplink … --port 4711` is refused here, naming both flags, rather than by a daemon at the next boot |
 | port mapping | there is no gateway on a cable and no port to forward |
 | hole punching | a point-to-point link has no translator to punch through |
 
-None of the three is a conflux flag, so none of them can collide with one: conflux
-does not pass a listen address, and it does not ask for port mapping or hole punching
-either, which is exactly what lets `conflux up --uplink /dev/ttyUSB0` work without
-also passing two flags to turn off.
+conflux does not pass a listen address, and it does not ask for port mapping or hole
+punching either, which is exactly what lets `conflux up --uplink /dev/ttyUSB0` work
+without also passing two flags to turn off. `--port` is the one of these that *is* a
+conflux flag, so it is the one that can collide — and conflux refuses the pair itself,
+naming both flags, rather than letting anchor refuse it at the next boot.
 
 Everything conflux *does* offer works over a link, including `--subnet` and both
 modes: the uplink is beneath all of it.
@@ -142,6 +144,47 @@ also bridge that cable into an IP-reachable realm — the wider realm learns an 
 anchor's record through gossip, since a record with no addresses still travels, but
 nothing in that realm can reach it.
 
-And one thing that reads like a limit and is one for now: **a link that ends, ends.**
-A device is not reopened, so an unplugged adapter needs the anchor restarted —
-`conflux up` with no flags does it, and reads the configuration for the rest.
+**A link that ends, ends — but conflux notices.** anchor does not reopen a device, so
+an unplugged adapter leaves the anchor holding a medium that carries nothing. Nothing
+else here would spot it: the supervisor watches the anchord *process*, and anchord
+does not exit — the daemon is fine, and only the anchor inside it is stranded. So a
+machine on a desk waits for somebody to type something, and an unattended one waits
+forever.
+
+On a machine configured for a link, conflux therefore watches it and rebuilds the
+anchor when it has ended:
+
+| Signal | |
+|---|---|
+| the device is gone from the filesystem | immediate — an unplugged adapter is not ambiguous |
+| `anchor_connections` has been zero for 90 seconds | the general case, and the one that catches a device still present whose line has died |
+
+A link is point-to-point and carries exactly one peer, which is what makes a
+connection count of zero mean something here and nothing on the host's network. The
+recovery is `anchorctl stop` and the same bring-up every boot performs, so the daemon
+is untouched, the identity is unchanged, nothing re-enrols, and the credential is
+renewed on the way through if it was due. Repeated failures back off from one second
+to thirty.
+
+The 90 seconds is not arbitrary: anchor redials an uplink on a two-second tick with a
+45-second dial timeout, and a realm handshake on the slowest line conflux accepts
+takes about 25. A shorter grace would restart anchors that were about to come up on
+their own.
+
+`conflux status` reports the count, because the anchor's own uptime cannot — it resets
+on every reopen, so a machine losing its cable hourly otherwise looks like one that
+has been up for fifty minutes:
+
+```console
+$ conflux status
+  uplink    3 reopens, last 2026-09-08T11:04:12Z
+```
+
+**The one case it gets wrong:** an idle link whose far end is legitimately switched
+off looks exactly like a dead one, and gets restarted. That is harmless — the restart
+re-dials, and a far end that comes back is found either way — but it is a restart
+nobody asked for, which is what the grace period and the backoff are there to keep
+rare. Distinguishing the two would need anchor to report the link's own state, and it
+does not.
+
+This is Unix-only, like `--uplink` itself.

--- a/internal/anchorctl/args.go
+++ b/internal/anchorctl/args.go
@@ -9,6 +9,7 @@ package anchorctl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/veil-net/conflux/internal/config"
@@ -38,6 +39,23 @@ type StartMode struct {
 	// the host's IP network. Orthogonal to every other field here: it decides the
 	// medium, and the rest decide what this machine does with the realm on it.
 	Uplink string
+
+	// Port is the UDP port to bind on every interface, or zero for the kernel's
+	// choice. Zero is not passed at all, for the reason -peers is not: the manifest
+	// carries a listenPort and anchorctl takes it for any field no flag named.
+	Port uint16
+
+	// LowLatency carries layer-2 frames on QUIC datagrams. Passed only when true --
+	// no manifest field describes it, so an omitted flag and an explicit false are
+	// the same instruction, and omitting keeps the argv shorter.
+	LowLatency bool
+
+	// ServeExit and UseExit route the public internet out of and into the overlay.
+	// Always passed, in both directions: the manifest does carry these two, and an
+	// anchor that became an exit because a document said so is a surprise conflux
+	// will not allow.
+	ServeExit bool
+	UseExit   bool
 }
 
 // ModeFromConfig reads the operator's intent into the shape Args needs.
@@ -51,6 +69,11 @@ func ModeFromConfig(c *config.Config, anchorDir string) StartMode {
 		IPv4:    c.IPv4,
 		Uplink:  c.Uplink,
 		Peers:   c.Peers,
+
+		Port:       c.Port,
+		LowLatency: c.LowLatency,
+		ServeExit:  c.ServeExit,
+		UseExit:    c.UseExit,
 	}
 
 	if m.TUN {
@@ -100,16 +123,30 @@ func (m StartMode) Args() []string {
 		args = append(args, "-uplink", m.Uplink)
 	}
 
+	// Only when set, like -peers and for the same reason: the manifest carries a
+	// listenPort, and a zero here means "no opinion" rather than "port zero".
+	// Refused beside an uplink, which binds no socket -- Validate catches that.
+	if m.Port != 0 {
+		args = append(args, "-port", strconv.FormatUint(uint64(m.Port), 10))
+	}
+
+	// Only when true. No manifest field describes low latency, so anchorctl's own
+	// default applies to an omitted flag and an explicit false says the same thing.
+	if m.LowLatency {
+		args = append(args, "-low-latency=true")
+	}
+
 	args = append(args, "-tun="+boolText(m.TUN))
 
 	if m.TUN && m.TUNName != "" {
 		args = append(args, "-tun-name", m.TUNName)
 	}
 
-	// conflux does not offer an exit in either mode, and says so rather than
-	// leaving it to the manifest: an anchor that silently became an internet exit
-	// because a document said so would be a surprise of the worst kind.
-	args = append(args, "-serve-exit=false", "-use-exit=false")
+	// Always both, in whichever direction, rather than leaving either to the
+	// manifest: an anchor that silently became an internet exit because a document
+	// said so would be a surprise of the worst kind. Off unless conflux was asked,
+	// and TUN-only -- Validate refuses the pair with userspace mode.
+	args = append(args, "-serve-exit="+boolText(m.ServeExit), "-use-exit="+boolText(m.UseExit))
 
 	if m.IPv4 != "" {
 		args = append(args, "-ipv4", m.IPv4)
@@ -143,6 +180,10 @@ func (m StartMode) Validate() error {
 		if m.IPv4 != "" {
 			return fmt.Errorf("an overlay IPv4 needs a host interface to assign it to")
 		}
+
+		if m.ServeExit || m.UseExit {
+			return fmt.Errorf("routing the public internet either way needs a host interface, which userspace mode has none of")
+		}
 	}
 
 	if len(m.Taints) == 0 {
@@ -152,6 +193,10 @@ func (m StartMode) Validate() error {
 	if m.Uplink != "" {
 		if _, err := config.ParseUplinkSpec(m.Uplink); err != nil {
 			return err
+		}
+
+		if m.Port != 0 {
+			return fmt.Errorf("an uplink binds no socket, so there is no port to choose")
 		}
 	}
 
@@ -171,6 +216,14 @@ func StopArgs() []string { return []string{"stop"} }
 
 // StatusArgs asks what is running.
 func StatusArgs() []string { return []string{"status"} }
+
+// MetricsArgs asks for the counters and gauges.
+//
+// conflux reads exactly one of them, anchor_connections, to tell a link that has
+// ended from one that is merely quiet. status cannot answer that: an anchor on an
+// uplink binds no socket, so it reports no underlay address and nothing else about
+// the link either.
+func MetricsArgs() []string { return []string{"metrics"} }
 
 func boolText(v bool) string {
 	if v {

--- a/internal/anchorctl/args_test.go
+++ b/internal/anchorctl/args_test.go
@@ -80,6 +80,29 @@ var scenarios = map[string]StartMode{
 		Proxies: []string{"8080=127.0.0.1:3000"},
 		Dir:     `C:\ProgramData\conflux\anchor`,
 	},
+	"up-port": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		Port: 4711, Dir: "/var/lib/conflux/anchor",
+	},
+	"up-low-latency": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		LowLatency: true, Dir: "/var/lib/conflux/anchor",
+	},
+	"up-exit": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		ServeExit: true, UseExit: true, Dir: "/var/lib/conflux/anchor",
+	},
+	"up-use-exit-only": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		UseExit: true, Dir: "/var/lib/conflux/anchor",
+	},
+	"proxy-low-latency": {
+		Taints:     []string{"brhk-2mq9-tzva-6pjs"},
+		Proxies:    []string{"8080=127.0.0.1:3000"},
+		Port:       4711,
+		LowLatency: true,
+		Dir:        "/var/lib/conflux/anchor",
+	},
 }
 
 func TestArgvGoldens(t *testing.T) {
@@ -115,7 +138,10 @@ func TestModeIsAlwaysExplicit(t *testing.T) {
 	for name, mode := range scenarios {
 		args := strings.Join(mode.Args(), " ")
 
-		for _, must := range []string{"-tun=", "-serve-exit=false", "-use-exit=false"} {
+		// The value is the operator's; being written at all is conflux's. An omitted
+		// flag is a field anchorctl takes from the manifest, so each of these must
+		// appear with an explicit =true or =false whichever way it was set.
+		for _, must := range []string{"-tun=", "-serve-exit=", "-use-exit="} {
 			if !strings.Contains(args, must) {
 				t.Errorf("%s: argv omits %s, which lets the manifest decide it", name, must)
 			}

--- a/internal/anchorctl/ctl.go
+++ b/internal/anchorctl/ctl.go
@@ -116,6 +116,17 @@ func (c *Ctl) Start(ctx context.Context, env config.Envelope, mode StartMode) (S
 	return s, nil
 }
 
+// Metrics reads the daemon's counters and gauges. An anchor that has not published
+// any yet is not an error; the map is simply empty.
+func (c *Ctl) Metrics(ctx context.Context) (map[string]float64, error) {
+	out, err := c.run(ctx, nil, MetricsArgs()...)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseMetrics(out), nil
+}
+
 // Status asks what is running. A daemon that is up with no anchor in it is not an
 // error -- it is the state conflux down leaves behind.
 func (c *Ctl) Status(ctx context.Context) (Status, error) {

--- a/internal/anchorctl/parse.go
+++ b/internal/anchorctl/parse.go
@@ -139,6 +139,40 @@ func ParseStatus(stdout string) Status {
 	return st
 }
 
+// MetricConnections is the gauge conflux watches: how many QUIC connections the
+// anchor is holding right now.
+//
+// On an uplink it is the whole story. A link is point-to-point and carries exactly
+// one peer, so a sustained zero is a link that has ended rather than a realm that is
+// quiet -- and anchor does not reopen a link that ends.
+const MetricConnections = "anchor_connections"
+
+// ParseMetrics reads the output of `anchorctl metrics`.
+//
+// One sample per line, name then value, padded by a tabwriter. Samples that are
+// neither a counter nor a gauge -- the observation summaries, "n=3 mean=..." -- have
+// no single value and are skipped rather than half-read. A labelled sample carries
+// its labels in the name, which is what keeps them distinct here.
+func ParseMetrics(stdout string) map[string]float64 {
+	out := map[string]float64{}
+
+	for line := range strings.Lines(stdout) {
+		name, value, ok := strings.Cut(strings.TrimSpace(line), "  ")
+		if !ok {
+			continue
+		}
+
+		v, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			continue
+		}
+
+		out[strings.TrimSpace(name)] = v
+	}
+
+	return out
+}
+
 // Cut reports whether this anchor's realm has been severed from the tree above it.
 // Its own peers still work; ours stop being reachable.
 func (s Status) Cut() bool { return s.CutDepth > 0 }

--- a/internal/anchorctl/parse_test.go
+++ b/internal/anchorctl/parse_test.go
@@ -153,3 +153,53 @@ func TestParseStartedIsResilient(t *testing.T) {
 		}
 	}
 }
+
+// metricsOutput is `anchorctl metrics` as a tabwriter pads it: the name, then two or
+// more spaces, then the value. The observation summary is there because it has no
+// single value and must be skipped rather than half-read.
+const metricsOutput = `anchor_connections            1
+anchor_peers_known            4
+anchor_peers_isolated         0
+anchor_connections_refused_total  0
+anchor_rtt{peer=anchorabc}    n=3 mean=12.5 min=9 max=18
+anchor_relay_bytes_total      918273
+`
+
+func TestParseMetrics(t *testing.T) {
+	got := ParseMetrics(metricsOutput)
+
+	for name, want := range map[string]float64{
+		MetricConnections:                  1,
+		"anchor_peers_known":               4,
+		"anchor_peers_isolated":            0,
+		"anchor_relay_bytes_total":         918273,
+		"anchor_connections_refused_total": 0,
+	} {
+		v, ok := got[name]
+		if !ok {
+			t.Errorf("%s missing from %v", name, got)
+
+			continue
+		}
+
+		if v != want {
+			t.Errorf("%s = %v, want %v", name, v, want)
+		}
+	}
+
+	// An observation summary has no single value, so it is skipped outright rather
+	// than parsed down to its first number.
+	if v, ok := got["anchor_rtt{peer=anchorabc}"]; ok {
+		t.Errorf("an observation summary should be skipped, got %v", v)
+	}
+}
+
+// TestParseMetricsIsResilient: no anchor, no metrics yet, and junk all give an empty
+// map rather than a panic. The supervisor reads this on a timer and must not die of it.
+func TestParseMetricsIsResilient(t *testing.T) {
+	for _, in := range []string{"", "no metrics yet\n", "garbage\n", "no anchor is running\n"} {
+		if got := ParseMetrics(in); len(got) != 0 {
+			t.Errorf("ParseMetrics(%q) = %v, want empty", in, got)
+		}
+	}
+}

--- a/internal/anchorctl/testdata/argv/proxy-low-latency.golden
+++ b/internal/anchorctl/testdata/argv/proxy-low-latency.golden
@@ -1,0 +1,15 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-port
+4711
+-low-latency=true
+-tun=false
+-serve-exit=false
+-use-exit=false
+-serve-proxy
+8080=127.0.0.1:3000

--- a/internal/anchorctl/testdata/argv/up-exit.golden
+++ b/internal/anchorctl/testdata/argv/up-exit.golden
@@ -1,0 +1,12 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-tun=true
+-tun-name
+anchor0
+-serve-exit=true
+-use-exit=true

--- a/internal/anchorctl/testdata/argv/up-low-latency.golden
+++ b/internal/anchorctl/testdata/argv/up-low-latency.golden
@@ -1,0 +1,13 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-low-latency=true
+-tun=true
+-tun-name
+anchor0
+-serve-exit=false
+-use-exit=false

--- a/internal/anchorctl/testdata/argv/up-port.golden
+++ b/internal/anchorctl/testdata/argv/up-port.golden
@@ -1,0 +1,14 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-port
+4711
+-tun=true
+-tun-name
+anchor0
+-serve-exit=false
+-use-exit=false

--- a/internal/anchorctl/testdata/argv/up-use-exit-only.golden
+++ b/internal/anchorctl/testdata/argv/up-use-exit-only.golden
@@ -1,0 +1,12 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-tun=true
+-tun-name
+anchor0
+-serve-exit=false
+-use-exit=true

--- a/internal/cli/bring.go
+++ b/internal/cli/bring.go
@@ -110,6 +110,20 @@ func waitForAnchor(ctx context.Context, d paths.Dirs) (anchorctl.Status, error) 
 }
 
 // report is what a person sees when it worked.
+// exitNote describes this machine's exit settings, or "" when it has neither.
+func exitNote(cfg *config.Config) string {
+	switch {
+	case cfg.ServeExit && cfg.UseExit:
+		return "serving a way out, and sending its own traffic over the overlay"
+	case cfg.ServeExit:
+		return "serving a way out to the public internet for the realm"
+	case cfg.UseExit:
+		return "sending this machine's internet traffic over the overlay"
+	default:
+		return ""
+	}
+}
+
 func report(d paths.Dirs, cfg *config.Config, st anchorctl.Status, verb string) {
 	mgr, _ := service.New()
 
@@ -137,6 +151,13 @@ func report(d paths.Dirs, cfg *config.Config, st anchorctl.Status, verb string) 
 
 	for _, s := range cfg.Subnets {
 		ui.Field("forwarding", s)
+	}
+
+	// Said whenever it is true, never when it is false. conflux goes to some trouble
+	// not to become an internet exit by accident, and a machine that is one should
+	// not need a config file read to find out.
+	if note := exitNote(cfg); note != "" {
+		ui.Field("exit", note)
 	}
 
 	ui.Field("taint", joinTaints(cfg.Taints))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,12 +33,13 @@ type verb struct {
 // verbs is the closed set of names conflux keeps for itself. Everything else
 // reaches anchorctl.
 //
-// Four of these shadow an anchorctl command -- proxy, renew, status and help -- and
+// Five of these shadow an anchorctl command -- start, proxy, renew, status and help -- and
 // each resolves its own collision rather than guessing. See the comment on each.
 func verbs() map[string]verb {
 	return map[string]verb{
 		"up":        {run: runUp, summary: "join the overlay with a network interface", usage: "conflux up [--taint T] [--ipv4 PREFIX | --no-ipv4] [--subnet CIDR]... [--uplink DEV | --no-uplink]"},
 		"proxy":     {run: runProxy, summary: "publish a local service on the overlay, without an interface", usage: "conflux proxy PORT[/NETWORK]=BACKEND ... [--uplink DEV | --no-uplink]"},
+		"start":     {run: runStart, summary: "start the anchor now, from the saved configuration", usage: "conflux start"},
 		"down":      {run: runDown, summary: "stop the anchor now; a reboot brings it back", usage: "conflux down"},
 		"renew":     {run: runRenew, summary: "install a fresh credential on the running anchor, now", usage: "conflux renew"},
 		"install":   {run: runInstall, summary: "register the boot service", usage: "conflux install"},
@@ -54,14 +55,18 @@ func verbs() map[string]verb {
 // anchorLifecycleVerbs are anchorctl commands conflux refuses to pass through
 // while it owns the configuration.
 //
-// Passing `start` through would build an anchor conflux does not know about, from
-// arguments its config file does not describe, which the next reboot would silently
-// replace. Passing `stop` through would stop one conflux believes is running. Both
-// are reachable through the escape hatch by anyone who means it.
+// Passing `stop` through would stop an anchor conflux believes is running, and
+// `restart` would rebuild one from arguments its config file does not describe, which
+// the next reboot would silently replace. Both are reachable through the escape hatch
+// by anyone who means it.
+//
+// `start` is absent because conflux has its own now. It used to be refused here and
+// answered with "up", which was wrong on a userspace machine: `up` re-decides the
+// configuration, changes the mode and drops the proxies. `restart` pointed at "up"
+// for the same reason and was wrong the same way, so it names `start`.
 var anchorLifecycleVerbs = map[string]string{
-	"start":   "up",
 	"stop":    "down",
-	"restart": "up",
+	"restart": "start",
 }
 
 // Main dispatches. It returns an exit code rather than calling os.Exit so that the

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -105,8 +105,11 @@ func anchorctlCommands(t *testing.T, bin string) map[string]bool {
 }
 
 func TestLifecycleVerbsAreRefusedWithTheAlternative(t *testing.T) {
+	// start is absent: conflux has its own now. restart names it rather than "up",
+	// which was wrong on a userspace machine -- up changes the mode and drops the
+	// proxies, so it is not the way back to what was running.
 	for name, want := range map[string]string{
-		"start": "conflux up", "stop": "conflux down", "restart": "conflux up",
+		"stop": "conflux down", "restart": "conflux start",
 	} {
 		_, errOut, code := capture(t, name)
 
@@ -121,6 +124,39 @@ func TestLifecycleVerbsAreRefusedWithTheAlternative(t *testing.T) {
 		if !strings.Contains(errOut, "conflux anchorctl "+name) {
 			t.Errorf("conflux %s should name the escape hatch; it said:\n%s", name, errOut)
 		}
+	}
+}
+
+// TestStartRefusesAnchorctlFlags: conflux's start takes no arguments, so a flag names
+// anchorctl's and is answered with both meanings rather than guessed at.
+func TestStartRefusesAnchorctlFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"start", "-cred", "x.cred"},
+		{"start", "-identity=k.key"},
+		{"start", "--root", "genesis.pub"},
+	} {
+		_, errOut, code := capture(t, args...)
+
+		if code != ExitUsage {
+			t.Errorf("conflux %v exited %d, want %d", args, code, ExitUsage)
+		}
+
+		if !strings.Contains(errOut, "conflux anchorctl start") {
+			t.Errorf("conflux %v should name the escape hatch; it said:\n%s", args, errOut)
+		}
+	}
+}
+
+// TestStartRefusesArguments: a positional is not conflux's start either.
+func TestStartRefusesArguments(t *testing.T) {
+	_, errOut, code := capture(t, "start", "somewhere")
+
+	if code != ExitUsage {
+		t.Errorf("conflux start somewhere exited %d, want %d", code, ExitUsage)
+	}
+
+	if !strings.Contains(errOut, "takes no arguments") {
+		t.Errorf("should say it takes no arguments; it said:\n%s", errOut)
 	}
 }
 

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -65,7 +65,16 @@ func install(ctx context.Context, d paths.Dirs, standalone bool) int {
 		ui.Warnf("%s", warning)
 	}
 
-	if err := mgr.Install(exe, "serve"); err != nil {
+	// A CONFLUX_DIR run registers a service that has to come back to that same
+	// directory. Passed as an argument rather than an environment variable because
+	// none of the three service managers carries the operator's environment into
+	// what it starts.
+	serveArgs := []string{"serve"}
+	if root := paths.Root(); root != "" {
+		serveArgs = append(serveArgs, "--dir", root)
+	}
+
+	if err := mgr.Install(exe, serveArgs...); err != nil {
 		if errors.Is(err, service.ErrUnsupported) {
 			ui.Errf("%v", err)
 

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/veil-net/conflux/internal/config"
 	"github.com/veil-net/conflux/internal/paths"
@@ -92,6 +93,16 @@ func install(ctx context.Context, d paths.Dirs, standalone bool) int {
 		return ExitOK
 	}
 
+	return startFromConfig(ctx, d, mgr, "install")
+}
+
+// startFromConfig starts the anchor this machine is already configured for.
+//
+// Shared by `install` and `start` so the two cannot drift into starting differently,
+// the same argument daemon.BringUp makes for `up`, `proxy` and every boot. The caller
+// has already established that a configuration exists and that the service is
+// registered; this is only the starting.
+func startFromConfig(ctx context.Context, d paths.Dirs, mgr service.Manager, verb string) int {
 	ui.Printf("Starting from the configuration in %s.\n", d.ConfigFile())
 
 	if err := mgr.Restart(); err != nil {
@@ -108,9 +119,105 @@ func install(ctx context.Context, d paths.Dirs, standalone bool) int {
 		return fail(err)
 	}
 
-	report(d, cfg, st, "install")
+	report(d, cfg, st, verb)
 
 	return ExitOK
+}
+
+// runStart starts the anchor now, from the configuration already on disk.
+//
+// The counterpart to down, and the reason it exists: down leaves the boot
+// registration and the configuration in place, so there has to be a word for "bring
+// that back now" that is not a reboot. That word used to be `conflux install`, whose
+// name and usage line both say "register the boot service" -- it started one as a
+// side effect, and pointing an operator at it was papering over a missing verb.
+//
+// Mode-agnostic on purpose. `up` would do for a TUN machine, but it is not a resume:
+// it re-decides the configuration, and on a userspace machine it changes the mode and
+// drops the proxies. A machine serving eight ports cannot be brought back by retyping
+// eight specs correctly from memory.
+func runStart(ctx context.Context, args []string) int {
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	fs.SetOutput(ui.Errw)
+	fs.Usage = func() {
+		ui.Printf("conflux start — start the anchor now, from the saved configuration\n\n" +
+			"  conflux start\n\n" +
+			"The counterpart to conflux down. Starts whatever this machine is already\n" +
+			"configured for, in whichever mode it names, and asks nothing. Nothing is\n" +
+			"enrolled and no configuration is invented.\n")
+	}
+
+	// anchorctl has a start of its own, and it is the one that takes flags: it
+	// builds an anchor from arguments the caller supplies. conflux's starts the one
+	// its configuration already describes, which is the whole difference and the
+	// reason it takes none. Resolve by shape, the way renew does.
+	if hint := anchorctlFlag(args); hint != "" {
+		ui.Errf("%q is anchorctl's start, not conflux's.\n\n"+
+			"  conflux start starts the anchor this machine is already configured for:\n\n"+
+			"    conflux start\n\n"+
+			"  To build an anchor from arguments of your own, that is anchorctl's, one word away:\n\n"+
+			"    conflux anchorctl start %s", hint, strings.Join(args, " "))
+
+		return ExitUsage
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+
+	if fs.NArg() > 0 {
+		ui.Errf("conflux start takes no arguments, and got %q.\n\n"+
+			"  conflux start", fs.Arg(0))
+
+		return ExitUsage
+	}
+
+	if err := privcheck.Require("starting the service", "conflux start"); err != nil {
+		return fail(fmt.Errorf("%w: %w", errNeedsRoot, err))
+	}
+
+	d := paths.Default()
+
+	mgr, err := service.New()
+	if err != nil {
+		return fail(err)
+	}
+
+	installed, err := mgr.Installed()
+	if err != nil {
+		return fail(err)
+	}
+
+	// Like down, start is defined against an installed service. Registering one here
+	// would be install's job done quietly, and a machine that gained a boot service
+	// because somebody typed "start" is a surprise at the next reboot rather than now.
+	if !installed {
+		ui.Errf("conflux is not installed here, so there is no service to start.\n\n" +
+			"  conflux install    register the boot service, and start it if configured\n" +
+			"  conflux up         join with a network interface\n" +
+			"  conflux proxy 8080=127.0.0.1:3000   publish a port, no interface needed")
+
+		return ExitUnavailable
+	}
+
+	// The same 78 the supervisor exits with, and for the same reason: there is a
+	// service here and nothing for it to run.
+	if _, err := config.Load(d); err != nil {
+		if !os.IsNotExist(err) {
+			return fail(err)
+		}
+
+		ui.Errf("There is no configuration on this machine, so there is nothing to start.\n\n" +
+			"  conflux up                          join with a network interface\n" +
+			"  conflux proxy 8080=127.0.0.1:3000   publish a port, no interface needed")
+
+		return ExitNoConfig
+	}
+
+	// No check for "already running". mgr.Restart covers both, and a start that
+	// refused a running anchor would be answering a question nobody asked -- the
+	// caller wants it up, and it ends up up.
+	return startFromConfig(ctx, d, mgr, "start")
 }
 
 // runDown stops the anchor now and leaves everything else alone.
@@ -163,7 +270,7 @@ func runDown(_ context.Context, args []string) int {
 
 	ui.Printf("Stopped. The boot service is still registered and the configuration is intact,\n" +
 		"so the next reboot brings this machine back exactly as it was.\n\n" +
-		"  conflux install    start it again now\n" +
+		"  conflux start      start it again now\n" +
 		"  conflux uninstall  remove it permanently\n")
 
 	return ExitOK

--- a/internal/cli/passthrough.go
+++ b/internal/cli/passthrough.go
@@ -68,9 +68,9 @@ func connectionDetails(d paths.Dirs, args []string) (string, bool) {
 
 	if _, err := os.Stat(d.Socket()); errors.Is(err, fs.ErrNotExist) {
 		ui.Errf("nothing is running here.\n\n"+
+			"  conflux start                       start from a configuration that already exists\n"+
 			"  conflux up                          join with a network interface\n"+
-			"  conflux proxy 8080=127.0.0.1:3000   publish a port, no interface needed\n"+
-			"  conflux install                     start from a configuration that already exists\n\n"+
+			"  conflux proxy 8080=127.0.0.1:3000   publish a port, no interface needed\n\n"+
 			"  (the control socket would be %s)", d.Socket())
 
 		return "", false

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -57,6 +57,14 @@ func runProxy(ctx context.Context, args []string) int {
 	noUplink := fs.Bool("no-uplink", false, "go back to the host's network on a machine configured for a link")
 	noPeers := fs.Bool("no-peers", false, "forget the bootstrap list and go back to the one enrolment supplies")
 	apiBase := fs.String("api", "", "enrolment API base URL")
+	port := fs.Uint("port", 0, "UDP port to bind on every interface; omit to let the kernel pick one")
+
+	// Read through typedFlags rather than by value; see the same block in up.go. The
+	// two exit flags are absent on purpose: both need a host interface, which
+	// userspace mode does not have.
+	fs.Bool("no-port", false, "go back to letting the kernel pick the port")
+	fs.Bool("low-latency", false, "carry frames on datagrams: no head-of-line blocking, and a lost frame stays lost")
+	fs.Bool("no-low-latency", false, "go back to carrying frames on streams")
 
 	fs.Var(&taints, "taint", "compartment label; repeat to carry more than one")
 	fs.Var(&peers, "peers", "bootstrap entry as host:port; repeat for more. Enrolment supplies these, so this is an override")
@@ -133,6 +141,11 @@ func runProxy(ctx context.Context, args []string) int {
 
 		cfg.Subnets = nil
 		cfg.IPv4 = ""
+
+		// Both exits need a host interface. Left set they would strand Validate on a
+		// setting the operator cannot see and did not type on this run.
+		cfg.ServeExit = false
+		cfg.UseExit = false
 	}
 
 	cfg.Mode = config.ModeProxy
@@ -154,6 +167,10 @@ func runProxy(ctx context.Context, args []string) int {
 		return fail(err)
 	}
 
+	if err := chooseTuning(cfg, typedFlags(fs), *port, false); err != nil {
+		return fail(err)
+	}
+
 	return bring(ctx, d, cfg, "proxy")
 }
 
@@ -168,6 +185,10 @@ func unknownProxyFlag(args []string) string {
 		"-no-uplink": true, "--no-uplink": true,
 		"-peers": true, "--peers": true,
 		"-no-peers": true, "--no-peers": true,
+		"-port": true, "--port": true,
+		"-no-port": true, "--no-port": true,
+		"-low-latency": true, "--low-latency": true,
+		"-no-low-latency": true, "--no-low-latency": true,
 		"-h": true, "--help": true, "-help": true,
 	}
 
@@ -216,10 +237,13 @@ func splitPositional(args []string) (positional, flags []string) {
 }
 
 // takesValue reports whether a flag written as `-flag value` swallows the argument
-// after it. Only conflux proxy's own value-taking flags are here; --no-taint and
-// --no-uplink are booleans and take nothing.
+// after it. Only conflux proxy's own value-taking flags are here; --no-taint,
+// --no-uplink and --low-latency are booleans and take nothing.
 func takesValue(arg string) bool {
-	name := strings.TrimLeft(arg, "-")
-
-	return name == "taint" || name == "api" || name == "uplink"
+	switch strings.TrimLeft(arg, "-") {
+	case "taint", "api", "uplink", "peers", "port":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -132,6 +132,11 @@ func runProxy(ctx context.Context, args []string) int {
 		return fail(err)
 	}
 
+	// Before the warning below; see the same move in up.go.
+	if err := chooseTuning(cfg, typedFlags(fs), *port, false); err != nil {
+		return fail(err)
+	}
+
 	if cfg.Mode == config.ModeTUN {
 		ui.Warnf("this machine was running in TUN mode with interface %s.\n"+
 			"  Userspace mode replaces that: one daemon holds one anchor, and an anchor with\n"+
@@ -164,10 +169,6 @@ func runProxy(ctx context.Context, args []string) int {
 	}
 
 	if err := chooseTaints(cfg, taints, *noTaint); err != nil {
-		return fail(err)
-	}
-
-	if err := chooseTuning(cfg, typedFlags(fs), *port, false); err != nil {
 		return fail(err)
 	}
 

--- a/internal/cli/renew.go
+++ b/internal/cli/renew.go
@@ -49,7 +49,7 @@ func runRenew(ctx context.Context, args []string) int {
 	// installs a credential the caller already holds. conflux's fetches one first,
 	// which is the whole difference and the reason it takes no arguments. Resolve
 	// by shape, the way proxy does, rather than shadowing anchorctl's outright.
-	if hint := anchorctlRenewFlag(args); hint != "" {
+	if hint := anchorctlFlag(args); hint != "" {
 		ui.Errf("%q is anchorctl's renew, not conflux's.\n\n"+
 			"  conflux renew fetches a fresh credential from the enrolment API and installs it:\n\n"+
 			"    conflux renew\n\n"+
@@ -96,7 +96,7 @@ func renewNow(ctx context.Context, d paths.Dirs) int {
 	// likely failure and deserves conflux's own answer rather than a dial error.
 	if _, err := os.Stat(d.Socket()); errors.Is(err, fs.ErrNotExist) {
 		ui.Errf("nothing is running here, and a credential is installed into a running anchor.\n\n"+
-			"  conflux install   start from the configuration this machine already has\n\n"+
+			"  conflux start     start from the configuration this machine already has\n\n"+
 			"  The next start renews on its own, so a machine that is meant to be down needs\n"+
 			"  nothing done here.\n\n"+
 			"  (the control socket would be %s)", d.Socket())
@@ -135,9 +135,13 @@ func renewNow(ctx context.Context, d paths.Dirs) int {
 	return ExitOK
 }
 
-// anchorctlRenewFlag reports the first flag that belongs to anchorctl's renew and
-// not to conflux's, which takes none.
-func anchorctlRenewFlag(args []string) string {
+// anchorctlFlag reports the first flag that must belong to anchorctl's version of a
+// shadowed verb rather than conflux's, which takes none.
+//
+// Shared by renew and start, which resolve their collisions the same way and for the
+// same reason: conflux's takes no arguments at all, so a flag is the signal, and -h
+// is the one that means the caller wants conflux's own usage.
+func anchorctlFlag(args []string) string {
 	for _, a := range args {
 		if !strings.HasPrefix(a, "-") {
 			continue

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"os"
 
 	"github.com/veil-net/conflux/internal/daemon"
 	"github.com/veil-net/conflux/internal/paths"
@@ -20,9 +21,25 @@ func runServe(ctx context.Context, args []string) int {
 	fs.SetOutput(ui.Errw)
 
 	foreground := fs.Bool("foreground", false, "stay in the foreground even where a service manager is available")
+	dir := fs.String("dir", "", "root every conflux path here, as CONFLUX_DIR does; the service registration passes it back")
 
 	if err := fs.Parse(args); err != nil {
 		return ExitUsage
+	}
+
+	// A service registered from a CONFLUX_DIR run has to come back to the same
+	// directory, and an environment variable does not survive the trip: systemd
+	// gives a unit a clean environment, launchd the same, and an SCM service
+	// inherits the system environment rather than the operator's. So install writes
+	// the root into the argv it registers, and this is where it is picked back up.
+	//
+	// Through the environment rather than by threading a Dirs everywhere, so that
+	// every paths.Default in this process agrees with this one. Before anything
+	// starts, so there is no goroutine to race.
+	if *dir != "" {
+		if err := os.Setenv("CONFLUX_DIR", *dir); err != nil {
+			return fail(err)
+		}
 	}
 
 	d := paths.Default()

--- a/internal/cli/service_windows.go
+++ b/internal/cli/service_windows.go
@@ -22,7 +22,7 @@ func serveAsService(sup *daemon.Supervisor) (bool, int) {
 
 	h := &handler{sup: sup}
 
-	if err := svc.Run(service.ServiceName, h); err != nil {
+	if err := svc.Run(service.ServiceName(), h); err != nil {
 		return true, ExitChildFailed
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,6 +142,22 @@ func reportCredential(d paths.Dirs) {
 	if st.LastRenewalError != "" {
 		ui.Field("renewal", "failing since "+st.LastRenewalTry.Format(time.RFC3339)+": "+st.LastRenewalError)
 	}
+
+	// A link that keeps ending is a failing cable, and the anchor's own uptime
+	// cannot say so: it resets on every reopen, so a machine losing its link hourly
+	// looks like one that has been up for fifty minutes.
+	if st.LinkReopens > 0 {
+		ui.Field("uplink", plural(st.LinkReopens, "reopen")+", last "+st.LastLinkReopen.Format(time.RFC3339))
+	}
+}
+
+// plural renders a count with its noun, so "1 reopen" does not read as a typo.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+
+	return strconv.Itoa(n) + " " + noun + "s"
 }
 
 func reportBinaries(d paths.Dirs) {
@@ -150,7 +167,7 @@ func reportBinaries(d paths.Dirs) {
 	}
 
 	if st.BinSetID != anchor.SetID() {
-		ui.Field("binaries", "stale — conflux was upgraded; run \"conflux install\" to restart onto the new anchor")
+		ui.Field("binaries", "stale — conflux was upgraded; run \"conflux start\" to restart onto the new anchor")
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -77,6 +77,10 @@ func reportConfig(cfg *config.Config) {
 		ui.Field("mode", "proxy — userspace, no host interface")
 	}
 
+	if note := exitNote(cfg); note != "" {
+		ui.Field("exit", note)
+	}
+
 	ui.Field("taint", joinTaints(cfg.Taints))
 
 	// Only when overridden. Silence here means the manifest's own list, which is

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -38,8 +38,19 @@ func runUp(ctx context.Context, args []string) int {
 		noUplink = fs.Bool("no-uplink", false, "go back to the host's network on a machine configured for a link")
 		noPeers  = fs.Bool("no-peers", false, "forget the bootstrap list and go back to the one enrolment supplies")
 		apiBase  = fs.String("api", "", "enrolment API base URL")
+		port     = fs.Uint("port", 0, "UDP port to bind on every interface; omit to let the kernel pick one")
 		peers    repeated
 	)
+
+	// Registered for the flag package and read through typedFlags, not through these
+	// values: what matters is whether they were written, not what they default to.
+	fs.Bool("no-port", false, "go back to letting the kernel pick the port")
+	fs.Bool("low-latency", false, "carry frames on datagrams: no head-of-line blocking, and a lost frame stays lost")
+	fs.Bool("no-low-latency", false, "go back to carrying frames on streams")
+	fs.Bool("serve-exit", false, "offer this machine as a way out to the public internet")
+	fs.Bool("no-serve-exit", false, "stop offering a way out")
+	fs.Bool("use-exit", false, "send this machine's own internet traffic over the overlay")
+	fs.Bool("no-use-exit", false, "send this machine's internet traffic the ordinary way")
 
 	fs.Var(&taints, "taint", "compartment label; repeat to carry more than one")
 	fs.Var(&subnets, "subnet", "a network this machine forwards for the realm; repeat for more")
@@ -118,7 +129,102 @@ func runUp(ctx context.Context, args []string) int {
 		return fail(err)
 	}
 
+	if err := chooseTuning(cfg, typedFlags(fs), *port, true); err != nil {
+		return fail(err)
+	}
+
 	return bring(ctx, d, cfg, "up")
+}
+
+// typedFlags records which flags were actually written, rather than which have a
+// non-zero value.
+//
+// The distinction is the whole of how a persisted setting is kept: `--port 0` and no
+// --port at all are the same value and opposite instructions, and a boolean that
+// defaults false cannot say "leave it alone" by its value either. anchorctl draws the
+// same line with fs.Visit, for the same reason.
+func typedFlags(fs *flag.FlagSet) map[string]bool {
+	typed := map[string]bool{}
+
+	fs.Visit(func(f *flag.Flag) { typed[f.Name] = true })
+
+	return typed
+}
+
+// chooseToggle resolves a --x / --no-x pair against what is already configured.
+//
+// Every persisted answer needs a way back, which is what the negation is for: a
+// machine configured once with --low-latency cannot be talked out of it by omitting
+// the flag, because omitting it is how every other re-run keeps its settings.
+func chooseToggle(name string, typed map[string]bool, current bool) (bool, error) {
+	on, off := typed[name], typed["no-"+name]
+
+	switch {
+	case on && off:
+		return false, fmt.Errorf("--%s and --no-%s contradict each other", name, name)
+	case on:
+		return true, nil
+	case off:
+		return false, nil
+	default:
+		return current, nil
+	}
+}
+
+// choosePort decides the UDP port, keeping a persisted one when no flag names one.
+func choosePort(cfg *config.Config, typed map[string]bool, value uint) error {
+	on, off := typed["port"], typed["no-port"]
+
+	switch {
+	case on && off:
+		return fmt.Errorf("--port and --no-port contradict each other")
+	case off:
+		cfg.Port = 0
+	case on:
+		// Zero is the kernel's choice rather than a port, so it cannot be asked for
+		// by number without the request being ambiguous with not asking at all.
+		if value == 0 || value > 65535 {
+			return fmt.Errorf(
+				"--port %d is not a port: it must be 1-65535, and --no-port is how to go back to letting the kernel pick one",
+				value)
+		}
+
+		cfg.Port = uint16(value)
+	}
+
+	return nil
+}
+
+// chooseTuning applies the settings that are neither the mode nor the medium.
+//
+// exits is false on proxy, where the two exit flags are not registered at all: both
+// need a host interface, so offering them on the verb that has none would be offering
+// a setting whose only outcome is a refusal.
+func chooseTuning(cfg *config.Config, typed map[string]bool, port uint, exits bool) error {
+	if err := choosePort(cfg, typed, port); err != nil {
+		return err
+	}
+
+	lowLatency, err := chooseToggle("low-latency", typed, cfg.LowLatency)
+	if err != nil {
+		return err
+	}
+
+	cfg.LowLatency = lowLatency
+
+	if !exits {
+		return nil
+	}
+
+	if cfg.ServeExit, err = chooseToggle("serve-exit", typed, cfg.ServeExit); err != nil {
+		return err
+	}
+
+	if cfg.UseExit, err = chooseToggle("use-exit", typed, cfg.UseExit); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // loadOrNew reads the existing configuration, or starts a fresh one.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -86,6 +86,14 @@ func runUp(ctx context.Context, args []string) int {
 		return fail(err)
 	}
 
+	// Before the warning below, because a flag that is going to be refused should be
+	// refused before this machine is told its proxies are being replaced. The
+	// announcement is not a lie -- nothing is saved until bring -- but reading
+	// "replaces that" and then an error is a worse way to learn you typo'd a port.
+	if err := chooseTuning(cfg, typedFlags(fs), *port, true); err != nil {
+		return fail(err)
+	}
+
 	// Switching a proxy machine to TUN is a real change of shape, not an edit.
 	if cfg.Mode == config.ModeProxy && len(cfg.Proxies) > 0 {
 		ui.Warnf("this machine was serving %d proxied service(s) in userspace mode.\n"+
@@ -126,10 +134,6 @@ func runUp(ctx context.Context, args []string) int {
 	cfg.IPv4 = address
 
 	if err := chooseTaints(cfg, taints, *noTaint); err != nil {
-		return fail(err)
-	}
-
-	if err := chooseTuning(cfg, typedFlags(fs), *port, true); err != nil {
 		return fail(err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,32 @@ type Config struct {
 	// know about, which in practice means testing.
 	Peers []string `json:"peers,omitempty"`
 
+	// Port is the UDP port to bind on every interface, or zero to let the kernel
+	// pick one. An anchor listens on every interface and only the port is
+	// configurable, so this is a port and not an address: the host's addresses
+	// change underneath it, and pinning one is a promise the host cannot keep.
+	//
+	// Zero is not passed to anchorctl at all, which is what leaves the manifest's
+	// own listenPort in play -- the same rule Peers follows, for the same reason.
+	// Meaningless beside an Uplink, where no socket is bound, and refused there.
+	Port uint16 `json:"port,omitempty"`
+
+	// LowLatency carries layer-2 frames on QUIC datagrams: no head-of-line
+	// blocking between flows to one peer, and a lost frame stays lost rather than
+	// holding up the ones behind it. A real trade rather than a better setting, so
+	// it is off unless asked for.
+	LowLatency bool `json:"lowLatency,omitempty"`
+
+	// ServeExit offers this anchor as a way out to the public internet, and
+	// UseExit sends this machine's own internet traffic over the overlay. Both
+	// need a host interface, so both are TUN only.
+	//
+	// Off by default and always passed explicitly, because an anchor that became
+	// an internet exit on its own -- because a manifest said so -- is the worst
+	// kind of surprise.
+	ServeExit bool `json:"serveExit,omitempty"`
+	UseExit   bool `json:"useExit,omitempty"`
+
 	TUNName    string `json:"tunName,omitempty"`
 	APIBaseURL string `json:"apiBaseUrl,omitempty"`
 
@@ -151,6 +177,13 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("mode is %q and an overlay IPv4 is set: there is no host interface to assign it to", c.Mode)
 		}
 
+		if c.ServeExit || c.UseExit {
+			return fmt.Errorf(
+				"mode is %q and an exit is set: routing the public internet either way needs a host interface, "+
+					"which userspace mode does not have",
+				c.Mode)
+		}
+
 	default:
 		return fmt.Errorf("mode is %q, want %q or %q", c.Mode, ModeTUN, ModeProxy)
 	}
@@ -180,6 +213,16 @@ func (c *Config) Validate() error {
 	if c.Uplink != "" {
 		if _, err := ParseUplinkSpec(c.Uplink); err != nil {
 			return err
+		}
+
+		// anchor refuses the pair rather than ignoring the port, and it is right to:
+		// a link binds no socket, so a port names nothing. Caught here so the message
+		// can name both conflux flags instead of arriving from a child process.
+		if c.Port != 0 {
+			return fmt.Errorf(
+				"a port and an uplink are set together: an uplink carries layer 1 over %s and binds no socket, "+
+					"so there is no port to choose",
+				c.Uplink)
 		}
 	}
 

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -48,6 +48,16 @@ type State struct {
 	// health it cannot vouch for.
 	LastRenewalError string    `json:"lastRenewalError,omitempty"`
 	LastRenewalTry   time.Time `json:"lastRenewalTry,omitzero"`
+
+	// LinkReopens and LastLinkReopen record an uplink found dead and rebuilt.
+	//
+	// Persisted rather than counted in memory because the supervisor that does the
+	// reopening and the `conflux status` that reports it are different processes. A
+	// machine quietly restarting its anchor every few minutes is a failing cable,
+	// and it should be legible as one rather than as an anchor that has been up all
+	// along -- the uptime resets, so nothing else would say.
+	LinkReopens    int       `json:"linkReopens,omitempty"`
+	LastLinkReopen time.Time `json:"lastLinkReopen,omitzero"`
 }
 
 // LoadState reads it. A missing file is an empty State and not an error: every

--- a/internal/config/tuning_test.go
+++ b/internal/config/tuning_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/veil-net/conflux/internal/paths"
+)
+
+// dirsForTest roots every conflux path in a temporary directory, the way CONFLUX_DIR
+// does for a dev run.
+func dirsForTest(t *testing.T) paths.Dirs {
+	t.Helper()
+	t.Setenv("CONFLUX_DIR", t.TempDir())
+
+	d := paths.Default()
+	if err := d.EnsureAll(); err != nil {
+		t.Fatalf("EnsureAll: %v", err)
+	}
+
+	return d
+}
+
+// base is a configuration that validates, so each case below changes exactly one
+// thing and the failure names that thing rather than a missing taint.
+func base(mode Mode) *Config {
+	c := &Config{Mode: mode, Taints: []string{"office"}}
+	if mode == ModeProxy {
+		c.Proxies = []string{"8080=127.0.0.1:3000"}
+	}
+
+	return c
+}
+
+func TestExitNeedsAHostInterface(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*Config)
+	}{
+		{"serve", func(c *Config) { c.ServeExit = true }},
+		{"use", func(c *Config) { c.UseExit = true }},
+		{"both", func(c *Config) { c.ServeExit, c.UseExit = true, true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// TUN is where an exit belongs, and it must keep working.
+			tun := base(ModeTUN)
+			tc.set(tun)
+
+			if err := tun.Validate(); err != nil {
+				t.Errorf("TUN mode should allow an exit: %v", err)
+			}
+
+			// Userspace has no interface to route out of, and anchor refuses it.
+			proxy := base(ModeProxy)
+			tc.set(proxy)
+
+			err := proxy.Validate()
+			if err == nil {
+				t.Fatal("userspace mode should refuse an exit")
+			}
+
+			if !strings.Contains(err.Error(), "host interface") {
+				t.Errorf("the error should say why; it said: %v", err)
+			}
+		})
+	}
+}
+
+func TestPortAndUplinkAreRefusedTogether(t *testing.T) {
+	c := base(ModeTUN)
+	c.Uplink = "/dev/ttyUSB0"
+	c.Port = 4711
+
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("a port beside an uplink should be refused: no socket is bound")
+	}
+
+	if !strings.Contains(err.Error(), "no port to choose") {
+		t.Errorf("the error should say why; it said: %v", err)
+	}
+
+	// Either alone is fine.
+	c.Port = 0
+	if err := c.Validate(); err != nil {
+		t.Errorf("an uplink alone should validate: %v", err)
+	}
+
+	c.Uplink, c.Port = "", 4711
+	if err := c.Validate(); err != nil {
+		t.Errorf("a port alone should validate: %v", err)
+	}
+}
+
+// TestTuningSurvivesTheRoundTrip: the four new fields are omitempty, so a zero value
+// is absent from the document. What must not happen is a set one being dropped.
+func TestTuningSurvivesTheRoundTrip(t *testing.T) {
+	d := dirsForTest(t)
+
+	want := base(ModeTUN)
+	want.Port = 4711
+	want.LowLatency = true
+	want.ServeExit = true
+	want.UseExit = true
+
+	if err := Save(d, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := Load(d)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got.Port != want.Port || got.LowLatency != want.LowLatency ||
+		got.ServeExit != want.ServeExit || got.UseExit != want.UseExit {
+		t.Errorf("tuning did not survive: port=%d lowLatency=%v serveExit=%v useExit=%v",
+			got.Port, got.LowLatency, got.ServeExit, got.UseExit)
+	}
+}

--- a/internal/daemon/link.go
+++ b/internal/daemon/link.go
@@ -1,0 +1,203 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/veil-net/conflux/internal/anchorctl"
+	"github.com/veil-net/conflux/internal/config"
+)
+
+// The link watcher, and why it has to exist.
+//
+// An anchor on an uplink reaches the realm over a link rather than a socket, and
+// anchor does not reopen a link that ends: an unplugged adapter, a cable pulled, a
+// far end power-cycled, and the anchor stays up holding a medium that carries
+// nothing. Restarting it is the documented answer.
+//
+// Nothing else here would notice. The supervisor watches the anchord *process*, and
+// anchord does not exit -- it has no reason to, the daemon is fine and only the
+// anchor inside it is stranded. So on a desk somebody eventually types `conflux up`,
+// and on the unattended serial deployments this pathway exists for, nobody does.
+const (
+	// linkCheckInterval is how often the gauge is read. Cheap: one control-socket
+	// round trip to a daemon on the same machine.
+	linkCheckInterval = 10 * time.Second
+
+	// linkGrace is how long the connection count must stay at zero before the link
+	// is called dead.
+	//
+	// Above anchor's own UplinkDialTimeout (45s) plus its two-second keeper tick, so
+	// a link still dialling is never mistaken for one that has ended, and above the
+	// ~25s a realm handshake needs on a 9600-baud line -- the slowest speed conflux
+	// accepts. The cost of being wrong is one restart; the cost of being hasty is a
+	// restart that interrupts a handshake that was about to succeed.
+	linkGrace = 90 * time.Second
+
+	// linkBackoffMin and linkBackoffMax bound how fast reopening is retried. A link
+	// whose far end is simply switched off would otherwise restart every 90 seconds
+	// forever.
+	linkBackoffMin = 1 * time.Second
+	linkBackoffMax = 30 * time.Second
+)
+
+// linkLoop watches an uplink and restarts the anchor when the link has ended.
+//
+// Only runs for an anchor configured with one. On the host's IP network this whole
+// question belongs to anchor, which handles a network change in-process by rebinding
+// and migrating its connections, and needs nothing from conflux.
+func (s *Supervisor) linkLoop(ctx context.Context, spec string) {
+	// Windows has no uplink at all: anchor cannot open a link there, and `conflux up`
+	// refuses --uplink rather than letting a service fail at boot on it.
+	if runtime.GOOS == "windows" || spec == "" {
+		return
+	}
+
+	device := devicePath(spec)
+	backoff := linkBackoffMin
+
+	// zeroSince is when the connection count was first seen at zero, or the zero
+	// time when the link is carrying something.
+	var zeroSince time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(linkCheckInterval):
+		}
+
+		dead, reason := s.linkIsDead(ctx, device, &zeroSince)
+		if !dead {
+			backoff = linkBackoffMin
+
+			continue
+		}
+
+		s.report().Warn("the uplink %s %s; restarting the anchor", spec, reason)
+
+		if err := s.reopenLink(ctx); err != nil {
+			s.report().Warn("could not restart the anchor on %s: %v", spec, err)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+
+			if backoff *= 2; backoff > linkBackoffMax {
+				backoff = linkBackoffMax
+			}
+
+			continue
+		}
+
+		s.links.Add(1)
+		s.recordReopen()
+		s.report().Step("the anchor is back on %s", spec)
+
+		// Whatever the state was, it is a fresh link now.
+		zeroSince = time.Time{}
+		backoff = linkBackoffMin
+	}
+}
+
+// linkIsDead decides whether the link has ended, and says why.
+//
+// Two signals. A device that has gone from the filesystem is unambiguous and
+// immediate -- a USB serial adapter that was unplugged is simply not there any more.
+// A connection count held at zero past the grace period is the general case, and the
+// one that catches a device still present whose line has died.
+func (s *Supervisor) linkIsDead(ctx context.Context, device string, zeroSince *time.Time) (bool, string) {
+	if device != "" {
+		if _, err := os.Stat(device); errors.Is(err, fs.ErrNotExist) {
+			return true, "is gone from this machine"
+		}
+	}
+
+	probe, cancel := context.WithTimeout(ctx, stopTimeout)
+	defer cancel()
+
+	metrics, err := s.ctl.Metrics(probe)
+	if err != nil {
+		// The daemon not answering is the restart loop's business, not this one's.
+		// Treating it as a dead link would restart an anchor over a problem that
+		// has nothing to do with the medium.
+		return false, ""
+	}
+
+	if metrics[anchorctl.MetricConnections] > 0 {
+		*zeroSince = time.Time{}
+
+		return false, ""
+	}
+
+	now := time.Now()
+	if zeroSince.IsZero() {
+		*zeroSince = now
+
+		return false, ""
+	}
+
+	if now.Sub(*zeroSince) < linkGrace {
+		return false, ""
+	}
+
+	return true, "has carried nothing for " + now.Sub(*zeroSince).Truncate(time.Second).String()
+}
+
+// reopenLink stops the stranded anchor and builds it again from the configuration.
+//
+// BringUp rather than anything of its own: it is the path `up`, `proxy` and every
+// boot already take, so a link that came back cannot start a subtly different anchor
+// from the one a reboot would. The daemon is untouched, so this costs one anchor's
+// sessions and not the process.
+func (s *Supervisor) reopenLink(ctx context.Context) error {
+	stopCtx, cancel := context.WithTimeout(ctx, stopTimeout)
+	defer cancel()
+
+	// Best effort. The anchor being stopped is holding a medium that carries
+	// nothing, so a stop that cannot be delivered is not a reason to keep it.
+	_ = s.ctl.Stop(stopCtx)
+
+	_, err := BringUp(ctx, s.Dirs, s.ctl, s.report())
+
+	return err
+}
+
+// recordReopen notes the reopen where another process can see it.
+//
+// Best effort throughout: the anchor is back, which is the part that mattered, and
+// losing the count is not worth failing that. BringUp has just rewritten the state
+// file, so this reads it back rather than holding a stale copy across the restart.
+func (s *Supervisor) recordReopen() {
+	st, err := config.LoadState(s.Dirs)
+	if err != nil {
+		return
+	}
+
+	st.LinkReopens++
+	st.LastLinkReopen = time.Now().UTC()
+
+	if err := config.SaveState(s.Dirs, st); err != nil {
+		s.report().Warn("could not record the uplink reopen: %v", err)
+	}
+}
+
+// devicePath is the device an uplink spec names, or "" for a spec that names none.
+//
+// fd:N adopts a descriptor rather than opening anything, so there is no path to
+// watch -- and conflux refuses that form at the CLI anyway, since its own supervisor
+// is what starts anchord and hands it nothing to adopt.
+func devicePath(spec string) string {
+	parsed, err := config.ParseUplinkSpec(spec)
+	if err != nil {
+		return ""
+	}
+
+	return parsed.Path
+}

--- a/internal/daemon/link_test.go
+++ b/internal/daemon/link_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/veil-net/conflux/internal/anchorctl"
 )
 
 func TestDevicePath(t *testing.T) {
@@ -62,5 +64,21 @@ func TestLinkIsDeadWhenTheDeviceGoes(t *testing.T) {
 
 	if reason == "" {
 		t.Error("a dead link should say why")
+	}
+}
+
+// TestBusyInterfaceIsPermanent: two conflux installations on one machine both default
+// to anchor0, so this is the failure a second one hits every time. Retrying it to the
+// unit's 90-second timeout leaves the reason in the journal and nothing but "job
+// failed" in front of the operator.
+func TestBusyInterfaceIsPermanent(t *testing.T) {
+	err := &anchorctl.Error{
+		Args:   []string{"start", "-tun=true", "-tun-name", "anchor0"},
+		Code:   1,
+		Stderr: `anchorctl: starting: anchor: opening anchor0: tundev: creating "anchor0": device or resource busy`,
+	}
+
+	if !isPermanent(err) {
+		t.Error("a TUN name another interface holds should not be retried to the unit timeout")
 	}
 }

--- a/internal/daemon/link_test.go
+++ b/internal/daemon/link_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDevicePath(t *testing.T) {
+	for spec, want := range map[string]string{
+		"/dev/ttyUSB0":        "/dev/ttyUSB0",
+		"/dev/ttyUSB0:115200": "/dev/ttyUSB0",
+		"/dev/ttyS1:57600":    "/dev/ttyS1",
+
+		// fd:N adopts a descriptor and opens nothing, so there is no path to watch.
+		"fd:3": "",
+
+		// Not a spec at all. A watcher that cannot tell what it is looking at
+		// watches nothing rather than guessing at a filename.
+		"": "",
+	} {
+		if got := devicePath(spec); got != want {
+			t.Errorf("devicePath(%q) = %q, want %q", spec, got, want)
+		}
+	}
+}
+
+// TestGraceIsLongerThanAnchorsOwnDialling is the arithmetic the whole watcher rests
+// on. anchor redials an uplink on a 2s tick with a 45s dial timeout, and the slowest
+// line conflux accepts needs ~25s for a realm handshake. A grace shorter than that
+// would restart anchors that were about to come up on their own.
+func TestGraceIsLongerThanAnchorsOwnDialling(t *testing.T) {
+	const (
+		anchorDialTimeout = 45 * time.Second
+		slowestHandshake  = 25 * time.Second
+	)
+
+	if linkGrace <= anchorDialTimeout+slowestHandshake {
+		t.Errorf("linkGrace is %s, which does not outlast a %s dial plus a %s handshake",
+			linkGrace, anchorDialTimeout, slowestHandshake)
+	}
+
+	if linkCheckInterval >= linkGrace {
+		t.Errorf("linkCheckInterval %s is not shorter than linkGrace %s, so the grace could never be observed",
+			linkCheckInterval, linkGrace)
+	}
+}
+
+// TestLinkIsDeadWhenTheDeviceGoes: an unplugged adapter is unambiguous, and is not
+// made to wait out the grace period that exists for the ambiguous case.
+func TestLinkIsDeadWhenTheDeviceGoes(t *testing.T) {
+	s := &Supervisor{}
+
+	var zeroSince time.Time
+
+	missing := filepath.Join(t.TempDir(), "ttyUSB0")
+
+	dead, reason := s.linkIsDead(t.Context(), missing, &zeroSince)
+	if !dead {
+		t.Fatal("a device that is not there should be a dead link")
+	}
+
+	if reason == "" {
+		t.Error("a dead link should say why")
+	}
+}

--- a/internal/daemon/supervisor.go
+++ b/internal/daemon/supervisor.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/veil-net/conflux/internal/anchorctl"
@@ -63,7 +64,16 @@ type Supervisor struct {
 	ctl   *anchorctl.Ctl
 	tail  *ring
 	once  sync.Once
+
+	// links counts how many times a dead uplink has been reopened, so that a
+	// machine quietly restarting its anchor every few minutes says so in
+	// conflux status rather than looking like it has simply been up all along.
+	links atomic.Int64
 }
+
+// LinkReopens is how many times the uplink has been found dead and the anchor
+// rebuilt on it.
+func (s *Supervisor) LinkReopens() int64 { return s.links.Load() }
 
 func (s *Supervisor) report() Reporter {
 	if s.Reporter == nil {
@@ -206,6 +216,12 @@ func (s *Supervisor) cycle(ctx context.Context) error {
 	defer stopRenewals()
 
 	go s.renewLoop(renewCtx)
+
+	// Only for an anchor on a link. On the host's network a change is anchor's own
+	// business, and it recovers in-process without conflux knowing.
+	if cfg, err := config.Load(s.Dirs); err == nil && cfg.Uplink != "" {
+		go s.linkLoop(renewCtx, cfg.Uplink)
+	}
 
 	select {
 	case <-ctx.Done():

--- a/internal/daemon/supervisor.go
+++ b/internal/daemon/supervisor.go
@@ -464,6 +464,15 @@ func isPermanent(err error) bool {
 			"invalid argument",
 			"taints",
 			"matches nothing",
+
+			// An interface name another interface already holds. Not permanent in
+			// the strictest sense -- the holder could go away -- but it will not
+			// free itself inside thirty seconds of backoff, and two conflux
+			// installations on one machine hit this every time, because both
+			// default to anchor0. Retrying to the 90-second unit timeout buries the
+			// reason in the journal; failing in three seconds puts it in front of
+			// somebody who can pass --interface.
+			"device or resource busy",
 		} {
 			if strings.Contains(s, phrase) {
 				return true

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -36,7 +36,7 @@ type Dirs struct {
 // with the standing caveat that a boot service registered against a directory only
 // one user can read is a boot service that will not start.
 func Default() Dirs {
-	if root := os.Getenv("CONFLUX_DIR"); root != "" {
+	if root := Root(); root != "" {
 		return Dirs{
 			Config: root,
 			State:  root,
@@ -47,6 +47,15 @@ func Default() Dirs {
 
 	return platformDirs()
 }
+
+// Root is the CONFLUX_DIR override, or "" when this is an ordinary system install.
+//
+// Exported because the boot service has to know. A run rooted somewhere else is a
+// separate installation of conflux, not the machine's own, and registering it under
+// the machine's own service name would replace a real node with a test one -- so the
+// service package names itself after this, and passes it on to the supervisor it
+// registers, which would otherwise come back at boot reading /etc/conflux.
+func Root() string { return os.Getenv("CONFLUX_DIR") }
 
 // ConfigFile holds the operator's intent: mode, taints, addresses, proxies.
 func (d Dirs) ConfigFile() string { return filepath.Join(d.Config, "conflux.json") }

--- a/internal/service/scope.go
+++ b/internal/service/scope.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/veil-net/conflux/internal/paths"
+)
+
+// scope is what distinguishes a service registered against a CONFLUX_DIR from the
+// machine's own, and is "" for the ordinary install that has no CONFLUX_DIR at all.
+//
+// Without it there is one service name per machine, and a dev run rooted in /tmp
+// registers itself over the top of a real node: same unit path, same label, same SCM
+// entry. The data was isolated and the registration was not, which made "CONFLUX_DIR
+// cannot disturb a real machine" false in the one way that costs somebody a node.
+//
+// A hash of the root rather than the root itself, because a unit name cannot hold a
+// path -- slashes especially -- and a truncated one would collide between two dirs
+// with the same last segment. Four bytes: this distinguishes a handful of dev roots
+// on one machine, not a namespace.
+func scope() string {
+	root := paths.Root()
+	if root == "" {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(root))
+
+	return "-" + hex.EncodeToString(sum[:4])
+}

--- a/internal/service/scope_test.go
+++ b/internal/service/scope_test.go
@@ -1,0 +1,59 @@
+package service
+
+import "testing"
+
+func TestScopeIsEmptyForAnOrdinaryInstall(t *testing.T) {
+	t.Setenv("CONFLUX_DIR", "")
+
+	if got := scope(); got != "" {
+		t.Errorf("scope() = %q with no CONFLUX_DIR, want \"\" — the machine's own service keeps its plain name", got)
+	}
+}
+
+func TestScopeIsStableAndDistinct(t *testing.T) {
+	t.Setenv("CONFLUX_DIR", "/tmp/cfx-a")
+	a := scope()
+
+	if a == "" {
+		t.Fatal("a CONFLUX_DIR run must not share the machine's service name")
+	}
+
+	// Stable: the same root has to name the same service across runs, or uninstall
+	// could not find what install registered.
+	t.Setenv("CONFLUX_DIR", "/tmp/cfx-a")
+
+	if again := scope(); again != a {
+		t.Errorf("scope() = %q then %q for one root; a service nobody can name again is a service nobody can remove", a, again)
+	}
+
+	t.Setenv("CONFLUX_DIR", "/tmp/cfx-b")
+
+	if b := scope(); b == a {
+		t.Errorf("two roots both scoped to %q, so one dev run would still replace the other", b)
+	}
+
+	// Two roots ending in the same segment must not collide: a truncated path
+	// would, which is why this hashes the whole thing.
+	t.Setenv("CONFLUX_DIR", "/var/tmp/cfx-a")
+
+	if deep := scope(); deep == a {
+		t.Errorf("/tmp/cfx-a and /var/tmp/cfx-a both scoped to %q", deep)
+	}
+}
+
+// TestScopeIsNameSafe: whatever a root looks like, the scope has to be usable inside
+// a systemd unit name, a launchd label and an SCM entry. Hex and a hyphen are.
+func TestScopeIsNameSafe(t *testing.T) {
+	t.Setenv("CONFLUX_DIR", "/tmp/a b/c:d\\e*f")
+
+	got := scope()
+	if len(got) != 9 || got[0] != '-' {
+		t.Fatalf("scope() = %q, want a hyphen and eight hex digits", got)
+	}
+
+	for _, r := range got[1:] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Errorf("scope() = %q contains %q, which is not hex", got, r)
+		}
+	}
+}

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const (
-	label     = "org.veilnet.conflux"
-	plistPath = "/Library/LaunchDaemons/" + label + ".plist"
-	target    = "system/" + label
-)
+// Functions and not constants because a run rooted in a CONFLUX_DIR is a separate
+// installation and must not be registered over the machine's own; see scope.
+func label() string     { return "org.veilnet.conflux" + scope() }
+func plistPath() string { return "/Library/LaunchDaemons/" + label() + ".plist" }
+func target() string    { return "system/" + label() }
 
 // plistTemplate is the job conflux writes.
 //
@@ -47,7 +47,7 @@ type launchd struct{}
 
 func newManager() (Manager, error) { return launchd{}, nil }
 
-func (launchd) Name() string { return label }
+func (launchd) Name() string { return label() }
 
 func (l launchd) Install(exe string, args ...string) error {
 	var argv strings.Builder
@@ -56,38 +56,38 @@ func (l launchd) Install(exe string, args ...string) error {
 		fmt.Fprintf(&argv, "    <string>%s</string>\n", escapeXML(a))
 	}
 
-	plist := fmt.Sprintf(plistTemplate, label, argv.String())
+	plist := fmt.Sprintf(plistTemplate, label(), argv.String())
 
-	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil { //nolint:gosec // a plist is world-readable by design
-		return fmt.Errorf("write %s: %w", plistPath, err)
+	if err := os.WriteFile(plistPath(), []byte(plist), 0o644); err != nil { //nolint:gosec // a plist is world-readable by design
+		return fmt.Errorf("write %s: %w", plistPath(), err)
 	}
 
 	// Bootstrapping a job that is already loaded fails with "Operation already in
 	// progress", so unload first and ignore whatever that says.
-	_ = run("launchctl", "bootout", target)
+	_ = run("launchctl", "bootout", target())
 
-	if err := run("launchctl", "bootstrap", "system", plistPath); err != nil {
+	if err := run("launchctl", "bootstrap", "system", plistPath()); err != nil {
 		return err
 	}
 
 	// Bootstrapping loads it and RunAtLoad starts it, which Install is not meant to
 	// do. Stop it again, so that a machine with no configuration gets registration
 	// and nothing else -- the caller starts it when there is something to start.
-	_ = run("launchctl", "kill", "SIGTERM", target)
+	_ = run("launchctl", "kill", "SIGTERM", target())
 
-	return run("launchctl", "enable", target)
+	return run("launchctl", "enable", target())
 }
 
 func (l launchd) Remove() error {
 	var first error
 
-	if err := run("launchctl", "bootout", target); err != nil && first == nil {
+	if err := run("launchctl", "bootout", target()); err != nil && first == nil {
 		first = err
 	}
 
-	_ = run("launchctl", "disable", target)
+	_ = run("launchctl", "disable", target())
 
-	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) && first == nil {
+	if err := os.Remove(plistPath()); err != nil && !os.IsNotExist(err) && first == nil {
 		first = err
 	}
 
@@ -100,15 +100,15 @@ func (l launchd) Remove() error {
 
 // Start uses kickstart, which starts or restarts. The previous conflux re-ran
 // bootstrap, which fails with "37: Operation already in progress" on a loaded job.
-func (launchd) Start() error   { return run("launchctl", "kickstart", target) }
-func (launchd) Restart() error { return run("launchctl", "kickstart", "-k", target) }
+func (launchd) Start() error   { return run("launchctl", "kickstart", target()) }
+func (launchd) Restart() error { return run("launchctl", "kickstart", "-k", target()) }
 
 // Stop kills the process and leaves the job loaded, which is exactly the semantics
 // `conflux down` needs: stopped now, back at the next boot.
-func (launchd) Stop() error { return run("launchctl", "kill", "SIGTERM", target) }
+func (launchd) Stop() error { return run("launchctl", "kill", "SIGTERM", target()) }
 
 func (launchd) Installed() (bool, error) {
-	_, err := os.Stat(plistPath)
+	_, err := os.Stat(plistPath())
 	if err == nil {
 		return true, nil
 	}
@@ -121,7 +121,7 @@ func (launchd) Installed() (bool, error) {
 }
 
 func (launchd) Running() (bool, error) {
-	out, ok := query("launchctl", "print", target)
+	out, ok := query("launchctl", "print", target())
 	if !ok {
 		return false, nil
 	}
@@ -137,10 +137,10 @@ func (l launchd) Describe() string {
 
 	running, _ := l.Running()
 	if running {
-		return fmt.Sprintf("running (launchd: %s, at boot)", label)
+		return fmt.Sprintf("running (launchd: %s, at boot)", label())
 	}
 
-	return fmt.Sprintf("installed, not running (launchd: %s, at boot)", label)
+	return fmt.Sprintf("installed, not running (launchd: %s, at boot)", label())
 }
 
 func escapeXML(s string) string {

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -13,9 +13,12 @@ import (
 // The previous conflux wrote veilnet.service and then started, stopped and removed
 // "veilnet". That worked only because systemd appends .service to a bare name, and
 // would have broken silently the day anyone added a veilnet.socket beside it.
-const unitName = "conflux.service"
+//
+// A function and not a constant because a run rooted in a CONFLUX_DIR is a separate
+// installation and must not be registered over the machine's own; see scope.
+func unitName() string { return "conflux" + scope() + ".service" }
 
-const unitPath = "/etc/systemd/system/" + unitName
+func unitPath() string { return "/etc/systemd/system/" + unitName() }
 
 // unitTemplate is the unit conflux writes.
 //
@@ -72,7 +75,7 @@ type systemd struct{}
 
 func newManager() (Manager, error) { return systemd{}, nil }
 
-func (systemd) Name() string { return unitName }
+func (systemd) Name() string { return unitName() }
 
 func (s systemd) Install(exe string, args ...string) error {
 	execStart := exe
@@ -82,8 +85,8 @@ func (s systemd) Install(exe string, args ...string) error {
 
 	unit := fmt.Sprintf(unitTemplate, execStart)
 
-	if err := os.WriteFile(unitPath, []byte(unit), 0o644); err != nil { //nolint:gosec // a unit file is world-readable by design
-		return fmt.Errorf("write %s: %w", unitPath, err)
+	if err := os.WriteFile(unitPath(), []byte(unit), 0o644); err != nil { //nolint:gosec // a unit file is world-readable by design
+		return fmt.Errorf("write %s: %w", unitPath(), err)
 	}
 
 	if err := run("systemctl", "daemon-reload"); err != nil {
@@ -93,7 +96,7 @@ func (s systemd) Install(exe string, args ...string) error {
 	// Enable, and deliberately not start. Starting is the caller's decision, and
 	// `conflux install` on a machine with no configuration must register without
 	// starting anything.
-	return run("systemctl", "enable", unitName)
+	return run("systemctl", "enable", unitName())
 }
 
 func (s systemd) Remove() error {
@@ -108,14 +111,14 @@ func (s systemd) Remove() error {
 		}
 	}
 
-	note(run("systemctl", "disable", "--now", unitName))
+	note(run("systemctl", "disable", "--now", unitName()))
 
-	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(unitPath()); err != nil && !os.IsNotExist(err) {
 		note(err)
 	}
 
 	note(run("systemctl", "daemon-reload"))
-	_ = run("systemctl", "reset-failed", unitName)
+	_ = run("systemctl", "reset-failed", unitName())
 
 	if installed, _ := s.Installed(); installed {
 		return first
@@ -125,14 +128,14 @@ func (s systemd) Remove() error {
 	return nil
 }
 
-func (systemd) Start() error   { return run("systemctl", "start", unitName) }
-func (systemd) Stop() error    { return run("systemctl", "stop", unitName) }
-func (systemd) Restart() error { return run("systemctl", "restart", unitName) }
+func (systemd) Start() error   { return run("systemctl", "start", unitName()) }
+func (systemd) Stop() error    { return run("systemctl", "stop", unitName()) }
+func (systemd) Restart() error { return run("systemctl", "restart", unitName()) }
 
 // Installed is a stat rather than `systemctl list-unit-files`: cheaper, and it
 // answers correctly on a machine where systemd is not currently running.
 func (systemd) Installed() (bool, error) {
-	_, err := os.Stat(unitPath)
+	_, err := os.Stat(unitPath())
 	if err == nil {
 		return true, nil
 	}
@@ -145,7 +148,7 @@ func (systemd) Installed() (bool, error) {
 }
 
 func (systemd) Running() (bool, error) {
-	_, ok := query("systemctl", "is-active", "--quiet", unitName)
+	_, ok := query("systemctl", "is-active", "--quiet", unitName())
 
 	return ok, nil
 }
@@ -156,8 +159,8 @@ func (s systemd) Describe() string {
 		return "not installed"
 	}
 
-	state, _ := query("systemctl", "is-active", unitName)
-	enabled, _ := query("systemctl", "is-enabled", unitName)
+	state, _ := query("systemctl", "is-active", unitName())
+	enabled, _ := query("systemctl", "is-enabled", unitName())
 
 	if state == "" {
 		state = "unknown"
@@ -167,5 +170,5 @@ func (s systemd) Describe() string {
 		enabled = "unknown"
 	}
 
-	return fmt.Sprintf("%s (systemd: %s, %s at boot)", state, unitName, enabled)
+	return fmt.Sprintf("%s (systemd: %s, %s at boot)", state, unitName(), enabled)
 }

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -15,8 +15,6 @@ const (
 	// ServiceName has no space in it, deliberately. The previous conflux used
 	// "VeilNet Conflux" as the service name as well as the display name, which
 	// makes every sc.exe invocation quoting-sensitive for no benefit.
-	ServiceName = "conflux"
-
 	displayName = "VeilNet Conflux"
 	description = "Joins this machine to a VeilNet overlay."
 )
@@ -25,7 +23,13 @@ type scm struct{}
 
 func newManager() (Manager, error) { return scm{}, nil }
 
-func (scm) Name() string { return ServiceName }
+// ServiceName is the SCM entry conflux registers.
+//
+// A function and not a constant because a run rooted in a CONFLUX_DIR is a separate
+// installation and must not be registered over the machine's own; see scope.
+func ServiceName() string { return "conflux" + scope() }
+
+func (scm) Name() string { return ServiceName() }
 
 func (scm) Install(exe string, args ...string) error {
 	m, err := mgr.Connect()
@@ -43,7 +47,7 @@ func (scm) Install(exe string, args ...string) error {
 	}
 
 	// Already there is not a failure; it is an upgrade.
-	if existing, err := m.OpenService(ServiceName); err == nil {
+	if existing, err := m.OpenService(ServiceName()); err == nil {
 		defer existing.Close()
 
 		cfg.BinaryPathName = quoteCommand(exe, args)
@@ -58,7 +62,7 @@ func (scm) Install(exe string, args ...string) error {
 	// CreateService appends the arguments. The previous conflux omitted them
 	// entirely, so the registered service ran conflux with an empty argv tail and
 	// fell into the help text at every boot.
-	s, err := m.CreateService(ServiceName, exe, cfg, args...)
+	s, err := m.CreateService(ServiceName(), exe, cfg, args...)
 	if err != nil {
 		return fmt.Errorf("create the service: %w", err)
 	}
@@ -84,7 +88,7 @@ func (c scm) Remove() error {
 	}
 	defer m.Disconnect()
 
-	s, err := m.OpenService(ServiceName)
+	s, err := m.OpenService(ServiceName())
 	if err != nil {
 		return nil // already gone, which is what was asked for
 	}
@@ -104,7 +108,7 @@ func (scm) control(cmd svc.Cmd, want svc.State) error {
 	}
 	defer m.Disconnect()
 
-	s, err := m.OpenService(ServiceName)
+	s, err := m.OpenService(ServiceName())
 	if err != nil {
 		return fmt.Errorf("the conflux service is not registered: %w", err)
 	}
@@ -138,7 +142,7 @@ func (scm) Start() error {
 	}
 	defer m.Disconnect()
 
-	s, err := m.OpenService(ServiceName)
+	s, err := m.OpenService(ServiceName())
 	if err != nil {
 		return fmt.Errorf("the conflux service is not registered: %w", err)
 	}
@@ -162,7 +166,7 @@ func (scm) Installed() (bool, error) {
 	}
 	defer m.Disconnect()
 
-	s, err := m.OpenService(ServiceName)
+	s, err := m.OpenService(ServiceName())
 	if err != nil {
 		return false, nil
 	}
@@ -179,7 +183,7 @@ func (scm) Running() (bool, error) {
 	}
 	defer m.Disconnect()
 
-	s, err := m.OpenService(ServiceName)
+	s, err := m.OpenService(ServiceName())
 	if err != nil {
 		return false, nil
 	}
@@ -201,10 +205,10 @@ func (c scm) Describe() string {
 
 	running, _ := c.Running()
 	if running {
-		return fmt.Sprintf("running (service: %s, automatic at boot)", ServiceName)
+		return fmt.Sprintf("running (service: %s, automatic at boot)", ServiceName())
 	}
 
-	return fmt.Sprintf("installed, not running (service: %s, automatic at boot)", ServiceName)
+	return fmt.Sprintf("installed, not running (service: %s, automatic at boot)", ServiceName())
 }
 
 // quoteCommand renders a BinaryPathName the SCM will parse back correctly.

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -87,7 +87,20 @@ docker exec cfx-b sh -c 'test -f /var/lib/conflux/manifest.b64' \
 docker exec cfx-b sh -c '! ip link show anchor0' >/dev/null 2>&1 \
   || { echo "down left the interface up" >&2; exit 1; }
 
-say "and a reboot brings B back"
+say "start brings B back without a reboot, and without retyping anything"
+B_BEFORE=$(anchor_id cfx-b)
+docker exec cfx-b conflux start
+for _ in $(seq 40); do
+  docker exec cfx-b sh -c 'ip link show anchor0' >/dev/null 2>&1 && break
+  sleep 1
+done
+docker exec cfx-b sh -c 'ip link show anchor0' >/dev/null 2>&1 \
+  || { echo "start did not bring the interface back" >&2; exit 1; }
+[ "$(anchor_id cfx-b)" = "$B_BEFORE" ] \
+  || { echo "B's identity changed across down and start" >&2; exit 1; }
+
+say "down again, and a reboot brings B back"
+docker exec cfx-b conflux down
 B_ID=$(anchor_id cfx-b)
 docker restart cfx-b >/dev/null
 for _ in $(seq 40); do


### PR DESCRIPTION
Resyncs conflux against anchor HEAD, surfaces four settings anchor has had for a
while, and fixes three bugs found on the way.

## The resync found nothing to catch up on

anchor is pulled to `07b2ac9`. The embedded pair is rebuilt from `make release`
(pinned `realmtglwued…klasq`) and the stale darwin/amd64 pair is gone, but no code
change was needed for any of it:

| Assumed drift | Actual state |
|---|---|
| CLI surface changed | every flag conflux emits still exists, checked against source *and* the rebuilt binary |
| `-listen` → `-port` (`db13f15`) | misses conflux entirely — it never emitted `-listen`, and `docs/uplink.md` records that as deliberate |
| credential/enrol schema | anchor has no enrolment client; the contract is the manifest, still `formatVersion 1` / `kind "anchor"` with a lenient decode. `severedAt` is realm-manifest-only and never reaches conflux |
| taint semantics | already `-taints` plural with containment |
| FD-based L1 uplink | already implemented, `fd:N` deliberately refused |
| version | already `1.0.0-pre` |

anchor's new stale-peer cleanup and network-change recovery are entirely in-process —
no `os.Exit` outside `cmd/`, no fork — so the supervisor, `down` and `install` were
already correct.

## `conflux start`

`down` leaves the registration and the configuration in place and there was no word
for bringing that back before a reboot. `down`'s own trailer pointed at
`conflux install`, whose name says *register the boot service*.

Behind it was a real fault: `anchorLifecycleVerbs` mapped `start` **and** `restart` to
`up`, and on a userspace machine that advice converts the machine — `up` re-decides
the configuration, changes the mode and drops the proxies. Somebody who typed
`conflux start` on a machine serving eight ports and did as they were told lost all
eight. `start` is conflux's now, resolved against anchorctl's by shape exactly as
`renew` already is; `restart` names it. `install` and `uninstall` are unchanged.

## Four settings

`--port`, `--low-latency`, `--serve-exit`, `--use-exit`, persisted, each with a
negation. `-port` and `-low-latency` are emitted only when set — the manifest carries
`listenPort`, and low latency has no manifest field, so omitting is exactly
equivalent. That is why **all fourteen existing argv goldens are byte-identical**.
Exits stay always-explicit and are TUN-only.

## Three bugs

- **`CONFLUX_DIR` isolated the data and not the machine.** The unit path, launchd
  label and SCM entry are constants, so a dev run registered itself over a real
  node's — and the registration carried no root, so the supervisor came back at boot
  reading `/etc/conflux` while the CLI waited ninety seconds on a socket nothing would
  bind. The documented dev procedure could not work on any machine. The service is now
  named after the root and the root is written into the registered argv. An ordinary
  install is byte-for-byte the unit it always was.
- **`takesValue` omitted `peers`**, so `conflux proxy --peers host:port` in two-word
  form failed outright.
- **A dead uplink was invisible.** anchor does not reopen a link that ends and anchord
  never exits, so nothing noticed. Now watched via the `anchor_connections` gauge
  (90s grace, derived from anchor's own 45s dial timeout) plus immediate device
  disappearance, recovering through the shared `BringUp`.

## Verified

Live against `genesis.veilnet.com.au:4700` in the systemd container: real enrolment,
`peers=3`, `cut depth 0`. The `down`/`start` round trip in both modes including a
proxy machine with three specs coming back untyped; reboot keeping identity, port and
low-latency; `--port`/`--low-latency`/exits confirmed in the running anchor's own
`anchorctl config`; and — for the `CONFLUX_DIR` fix — a real node and a dev node side
by side on one machine, both surviving a reboot.

The no-`--peers` regression holds: with the override removed, `anchorctl config` still
showed `bootstrap: [genesis…]` supplied by the manifest.

All CI jobs pass locally, including under the placeholder binaries CI actually builds
with, and `go vet` including tests on all six non-host platforms.

## For the reviewer

- **`CONFLUX_DIR` changing the service name** is the one behaviour change beyond the
  brief. Propagating the root alone would have fixed the hang but left a dev run able
  to clobber a production node. Isolated in `internal/service/scope.go` if you want it
  pulled.
- **Not verified:** two machines on a real cable. The uplink watcher's reopen path is
  unit-tested and reasoned about, not exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
