### PR TITLE
The binary a developer installs was not the kind of binary that ships

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,19 @@ all: fmtcheck vet lint tidycheck test cross dist
 anchor-bins:
 	@ANCHOR_SRC=$(ANCHOR_SRC) ./scripts/anchor-bins.sh
 
+# CGO_ENABLED=0 here for the same reason cross and dist set it: so that the binary a
+# developer builds and installs is the same *kind* of binary as the one that ships.
+# Without it `make build` inherits the host default, which on any machine with a C
+# toolchain is cgo — and cgo pulls in the host's dynamic loader. Measured on the anchor
+# deployment: `make build` produced a dynamically linked conflux against a `make dist`
+# artifact that was static, and the dynamic one is what got installed to
+# /usr/local/bin. That build carries a glibc dependency the release artifact does not,
+# so it is a binary the release pipeline never tests and cannot be copied to a host with
+# an older libc. The two paths should differ in which target they build, and in nothing
+# else.
 build:
 	@mkdir -p $(BIN)
-	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(BIN)/conflux .
+	CGO_ENABLED=0 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(BIN)/conflux .
 	@ls -l $(BIN)/conflux | awk '{printf "  %.1f MB  $(BIN)/conflux\n", $$5/1048576}'
 
 test:


### PR DESCRIPTION
`cross` and `dist` both set `CGO_ENABLED=0`. `build` did not, so it took the host default — and on any machine with a C toolchain that is cgo, which links against the host's dynamic loader.

Measured rather than reasoned about. During a live audit pass, the conflux installed at `/usr/local/bin` on the anchor deployment was **dynamically linked**, while `dist/conflux-linux-amd64`, built from the same tree in the same afternoon, was **static**. So the artifact actually running was one the release pipeline never produces and never tests, carrying a glibc dependency the shipped one does not have — and it cannot be copied to a host with an older libc, which is the one thing a single static binary is for.

The two paths should differ in which target they build, and in nothing else.

## Test plan

- `make test` passes.
- `make build` now produces a statically linked binary, matching `dist`.
- The resulting build was deployed to both live anchors and verified end to end.

## Related

Pairs with veil-net/anchor#14, the anchor-side findings from the same audit pass. Note for that repo's parser: `internal/anchorctl` parses `renew by` into `Status.RenewBy` and never reads it — only `WorksUntil` is consumed. The anchor PR corrects the *value* that field carries while keeping the key and bare RFC3339 format, so this parser is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
