### PR TITLE
Eight tests that only ever skipped, and a setting only the issuer could make

### DIFF
--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -1,0 +1,110 @@
+name: anchor-bins
+description: >
+  Populate anchor/bin with real anchor binaries, built from a checkout of veil-net/anchor
+  beside this one. The one thing a runner could never do before.
+
+inputs:
+  token:
+    description: >
+      A token that can read veil-net/anchor. The repository is private, so the job's own
+      GITHUB_TOKEN cannot: it is scoped to conflux. Required.
+    required: true
+  ref:
+    description: Which anchor to build. Defaults to its default branch.
+    required: false
+    default: main
+
+runs:
+  using: composite
+  steps:
+    # Said first and on its own, because the alternative is discovering it from the
+    # middle of a checkout error that names a 404 rather than a permission.
+    - name: a token that can read anchor
+      shell: bash
+      run: |
+        set -eu
+        [ -n "${{ inputs.token }}" ] || {
+          echo "::error::this job needs a token that can read veil-net/anchor, which is private" >&2
+          echo "the job's GITHUB_TOKEN is scoped to conflux and cannot read it. Add a" >&2
+          echo "fine-grained PAT or GitHub App token with Contents: read on veil-net/anchor" >&2
+          echo "as the repository or organisation secret ANCHOR_READ_TOKEN." >&2
+          exit 1
+        }
+
+    - uses: actions/checkout@v7
+      with:
+        repository: veil-net/anchor
+        ref: ${{ inputs.ref }}
+        token: ${{ inputs.token }}
+        path: anchor
+
+    # anchor/dist is 16 binaries across 8 targets and dominates this job otherwise.
+    # Keyed on the anchor commit rather than on a lockfile: the binaries are a pure
+    # function of that tree and the toolchain, and the toolchain is in the key too.
+    - name: what anchor we are building
+      id: anchor
+      shell: bash
+      working-directory: anchor
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache@v4
+      id: cache
+      with:
+        path: anchor/dist
+        key: anchor-dist-${{ runner.os }}-${{ runner.arch }}-${{ steps.anchor.outputs.sha }}
+
+    # `make dist` and never `make release`, and this is the guard rather than a comment
+    # because the failure it prevents is invisible.
+    #
+    # release is the pinned, shippable build and it depends on genesis/genesis.pin. If
+    # genesis/ is absent -- and on a fresh checkout it always is -- the rule mints a
+    # brand new genesis root instead of failing. Binaries pinned to a realm nobody else
+    # has ever seen enrol against the live API perfectly and then never handshake, so
+    # the suite goes red somewhere in the overlay with nothing pointing back here.
+    - name: dist, never release
+      shell: bash
+      working-directory: anchor
+      run: |
+        set -eu
+        if [ -d genesis ]; then
+          echo "::error::anchor/genesis exists in a CI checkout, which it never should" >&2
+          echo "this job builds \`make dist\` and must not be near a genesis key." >&2
+          exit 1
+        fi
+        echo "no genesis/: \`make release\` cannot mint a root from here"
+
+    - name: build the anchor binaries
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: anchor
+      run: make dist
+
+    - name: put them where //go:embed can find them
+      shell: bash
+      working-directory: conflux
+      run: make anchor-bins
+
+    # Say what this run is actually carrying, because a green tick on an unpinned build
+    # means less than a green tick on a pinned one and the difference is invisible in
+    # the log otherwise.
+    #
+    # dist is unpinned: it will join any realm tree, which is exactly why it works
+    # against the live API's production realm here, and exactly why nothing built from
+    # it may ship. release.yml still refuses anything else.
+    - name: what these binaries are
+      shell: bash
+      working-directory: conflux
+      run: |
+        set -eu
+        echo "anchor: ${{ steps.anchor.outputs.sha }} (${{ inputs.ref }})"
+        echo "cache:  ${{ steps.cache.outputs.cache-hit == 'true' && 'hit' || 'miss, built here' }}"
+        echo
+        ls -lh anchor/bin
+        echo
+        smallest=$(find anchor/bin -type f -printf '%s\n' | sort -n | head -1)
+        [ "$smallest" -ge 5000000 ] || {
+          echo "::error::anchor/bin holds placeholders, not binaries: smallest file is $smallest bytes" >&2
+          exit 1
+        }
+        echo "PROVENANCE: unpinned \`make dist\`. Good for testing against the live realm,"
+        echo "and never shippable -- a conflux built from this joins any realm tree."

--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -21,9 +21,15 @@ runs:
     # middle of a checkout error that names a 404 rather than a permission.
     - name: a token that can read anchor
       shell: bash
+      # Through the environment rather than interpolated into the command line. Actions
+      # masks a secret in the log either way, but an expression is substituted into the
+      # script text itself, where a value containing a quote would end the string and
+      # what followed it would run.
+      env:
+        TOKEN: ${{ inputs.token }}
       run: |
         set -eu
-        [ -n "${{ inputs.token }}" ] || {
+        [ -n "${TOKEN:-}" ] || {
           echo "::error::this job needs a token that can read veil-net/anchor, which is private" >&2
           echo "the job's GITHUB_TOKEN is scoped to conflux and cannot read it. Add a" >&2
           echo "fine-grained PAT or GitHub App token with Contents: read on veil-net/anchor" >&2

--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -1,116 +1,45 @@
 name: anchor-bins
 description: >
-  Populate anchor/bin with real anchor binaries, built from a checkout of veil-net/anchor
-  beside this one. The one thing a runner could never do before.
+  Populate anchor/bin with the pinned anchor binaries, fetched from the published
+  release shelf. No checkout of anchor, and no credential.
 
 inputs:
-  token:
+  url:
     description: >
-      A token that can read veil-net/anchor. The repository is private, so the job's own
-      GITHUB_TOKEN cannot: it is scoped to conflux. Required.
-    required: true
-  ref:
-    description: Which anchor to build. Defaults to its default branch.
+      The release manifest. Defaults to the one internal/shelf names, so the value is
+      stated once in the product code rather than twice.
     required: false
-    default: main
+    default: ""
 
 runs:
   using: composite
   steps:
-    # Said first and on its own, because the alternative is discovering it from the
-    # middle of a checkout error that names a 404 rather than a permission.
-    - name: a token that can read anchor
+    # What this fetches is what conflux already ships: //go:embed puts these bytes
+    # inside every published conflux, so a public shelf discloses nothing a release
+    # download does not. That is why this needs no token for a private repository --
+    # conflux wants anchor's *output*, and the output is not the secret.
+    #
+    # And what it fetches is the *pinned* build, which a local `make dist` cannot be:
+    # an anchor pinned to the genesis realm refuses to handshake with any other tree.
+    # So the container suites below now exercise the binaries that actually ship.
+    - name: fetch the pinned anchor binaries
       shell: bash
-      # Through the environment rather than interpolated into the command line. Actions
-      # masks a secret in the log either way, but an expression is substituted into the
-      # script text itself, where a value containing a quote would end the string and
-      # what followed it would run.
       env:
-        TOKEN: ${{ inputs.token }}
+        SHELF_URL: ${{ inputs.url }}
+      run: make anchor-bins FETCH=1
+
+    # Say what arrived, because a green tick on fourteen files nobody looked at is
+    # worth less than it appears. The fetcher has already verified every digest against
+    # the manifest; this is the size floor that catches a placeholder fallback, which
+    # is the one way `make anchor-bins` can succeed while leaving nothing usable.
+    - name: they are binaries, not placeholders
+      shell: bash
       run: |
-        set -eu
-        [ -n "${TOKEN:-}" ] || {
-          echo "::error::this job needs a token that can read veil-net/anchor, which is private" >&2
-          echo "the job's GITHUB_TOKEN is scoped to conflux and cannot read it. Add a" >&2
-          echo "fine-grained PAT or GitHub App token with Contents: read on veil-net/anchor" >&2
-          echo "as the repository or organisation secret ANCHOR_READ_TOKEN." >&2
-          exit 1
-        }
-
-    - uses: actions/checkout@v7
-      with:
-        repository: veil-net/anchor
-        ref: ${{ inputs.ref }}
-        token: ${{ inputs.token }}
-        path: anchor
-
-    # anchor/dist is 16 binaries across 8 targets and dominates this job otherwise.
-    # Keyed on the anchor commit rather than on a lockfile: the binaries are a pure
-    # function of that tree and the toolchain, and the toolchain is in the key too.
-    - name: what anchor we are building
-      id: anchor
-      shell: bash
-      working-directory: anchor
-      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-    - uses: actions/cache@v4
-      id: cache
-      with:
-        path: anchor/dist
-        key: anchor-dist-${{ runner.os }}-${{ runner.arch }}-${{ steps.anchor.outputs.sha }}
-
-    # `make dist` and never `make release`, and this is the guard rather than a comment
-    # because the failure it prevents is invisible.
-    #
-    # release is the pinned, shippable build and it depends on genesis/genesis.pin. If
-    # genesis/ is absent -- and on a fresh checkout it always is -- the rule mints a
-    # brand new genesis root instead of failing. Binaries pinned to a realm nobody else
-    # has ever seen enrol against the live API perfectly and then never handshake, so
-    # the suite goes red somewhere in the overlay with nothing pointing back here.
-    - name: dist, never release
-      shell: bash
-      working-directory: anchor
-      run: |
-        set -eu
-        if [ -d genesis ]; then
-          echo "::error::anchor/genesis exists in a CI checkout, which it never should" >&2
-          echo "this job builds \`make dist\` and must not be near a genesis key." >&2
-          exit 1
-        fi
-        echo "no genesis/: \`make release\` cannot mint a root from here"
-
-    - name: build the anchor binaries
-      if: steps.cache.outputs.cache-hit != 'true'
-      shell: bash
-      working-directory: anchor
-      run: make dist
-
-    - name: put them where //go:embed can find them
-      shell: bash
-      working-directory: conflux
-      run: make anchor-bins
-
-    # Say what this run is actually carrying, because a green tick on an unpinned build
-    # means less than a green tick on a pinned one and the difference is invisible in
-    # the log otherwise.
-    #
-    # dist is unpinned: it will join any realm tree, which is exactly why it works
-    # against the live API's production realm here, and exactly why nothing built from
-    # it may ship. release.yml still refuses anything else.
-    - name: what these binaries are
-      shell: bash
-      working-directory: conflux
-      run: |
-        set -eu
-        echo "anchor: ${{ steps.anchor.outputs.sha }} (${{ inputs.ref }})"
-        echo "cache:  ${{ steps.cache.outputs.cache-hit == 'true' && 'hit' || 'miss, built here' }}"
-        echo
+        set -euo pipefail
         ls -lh anchor/bin
-        echo
         smallest=$(find anchor/bin -type f -printf '%s\n' | sort -n | head -1)
-        [ "$smallest" -ge 5000000 ] || {
-          echo "::error::anchor/bin holds placeholders, not binaries: smallest file is $smallest bytes" >&2
+        [ "${smallest:-0}" -ge 5000000 ] || {
+          echo "::error::anchor/bin holds placeholders, not binaries: smallest file is ${smallest:-0} bytes" >&2
+          echo "the shelf fetch fell back. Scroll up for why it failed." >&2
           exit 1
         }
-        echo "PROVENANCE: unpinned \`make dist\`. Good for testing against the live realm,"
-        echo "and never shippable -- a conflux built from this joins any realm tree."

--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -28,10 +28,11 @@ runs:
         SHELF_URL: ${{ inputs.url }}
       run: make anchor-bins FETCH=1
 
-    # Say what arrived, because a green tick on fourteen files nobody looked at is
-    # worth less than it appears. The fetcher has already verified every digest against
-    # the manifest; this is the size floor that catches a placeholder fallback, which
-    # is the one way `make anchor-bins` can succeed while leaving nothing usable.
+    # Say what arrived, because a green tick on fourteen files nobody looked at is worth
+    # less than it appears. The fetcher has already verified every digest against the
+    # manifest and a failed fetch is fatal, so this floor should never fire -- it is here
+    # for the case those two claims stop being true together, which is exactly the case
+    # nothing else would notice.
     - name: they are binaries, not placeholders
       shell: bash
       run: |
@@ -40,6 +41,7 @@ runs:
         smallest=$(find anchor/bin -type f -printf '%s\n' | sort -n | head -1)
         [ "${smallest:-0}" -ge 5000000 ] || {
           echo "::error::anchor/bin holds placeholders, not binaries: smallest file is ${smallest:-0} bytes" >&2
-          echo "the shelf fetch fell back. Scroll up for why it failed." >&2
+          echo "the fetch reported success and left placeholders behind, which should" >&2
+          echo "not be possible. Scroll up for what it actually did." >&2
           exit 1
         }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,10 +1,24 @@
 name: setup
 description: Go, from go.mod, with the module cache.
+
+inputs:
+  path:
+    description: >
+      Where the conflux checkout is, relative to the workspace. Defaults to the
+      workspace root; the jobs that check anchor out beside conflux pass "conflux".
+    required: false
+    default: .
+
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v7
       with:
         # From go.mod rather than pinned here, so the toolchain is stated once.
-        go-version-file: go.mod
-        cache-dependency-path: go.sum
+        #
+        # Both paths are resolved against the workspace root and not against this
+        # action, so a job that checked conflux out into a subdirectory would send
+        # setup-go looking for a go.mod that is not there -- and it fails with
+        # "Unable to find file" rather than with anything about the layout.
+        go-version-file: ${{ inputs.path }}/go.mod
+        cache-dependency-path: ${{ inputs.path }}/go.sum

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,24 +1,10 @@
 name: setup
 description: Go, from go.mod, with the module cache.
-
-inputs:
-  path:
-    description: >
-      Where the conflux checkout is, relative to the workspace. Defaults to the
-      workspace root; the jobs that check anchor out beside conflux pass "conflux".
-    required: false
-    default: .
-
 runs:
   using: composite
   steps:
     - uses: actions/setup-go@v7
       with:
         # From go.mod rather than pinned here, so the toolchain is stated once.
-        #
-        # Both paths are resolved against the workspace root and not against this
-        # action, so a job that checked conflux out into a subdirectory would send
-        # setup-go looking for a go.mod that is not there -- and it fails with
-        # "Unable to find file" rather than with anything about the layout.
-        go-version-file: ${{ inputs.path }}/go.mod
-        cache-dependency-path: ${{ inputs.path }}/go.sum
+        go-version-file: go.mod
+        cache-dependency-path: go.sum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,17 @@ permissions:
 # has — and everything on the runner queues behind everything else, so moving them there
 # would cost the machine's time to buy nothing.
 #
-# **This repository is public, and anchor is not.** That asymmetry is the whole of the
-# fork rule below. A self-hosted runner is a machine that survives the job, and conflux
-# has forks; `pull_request` runs the workflow from the *head* of the PR, so a fork could
-# otherwise propose a workflow that runs its own code on veilnet-dev, beside a Docker
-# socket and a token that reads a private repository. That is what GitHub's warning on
-# the "Allow public repositories" checkbox is about, and why that checkbox exists
-# separately from repository access at all.
+# **This repository is public.** A self-hosted runner is a machine that survives the job,
+# and conflux has forks; `pull_request` runs the workflow from the *head* of the PR, so
+# without a guard a fork could propose a workflow that runs its own code on veilnet-dev,
+# beside a Docker socket and whatever the last job left on disk. That is what GitHub's
+# warning on the "Allow public repositories" checkbox is about, and why that checkbox
+# exists separately from repository access at all.
+#
+# Fetching from the shelf rather than checking anchor out removes the sharpest version
+# of that -- there is no private source on the machine and no token in this repository's
+# secrets to reach for -- but the guard stays, because running a stranger's code on a
+# persistent machine is worth refusing on its own.
 #
 # So every self-hosted job carries a fork guard, and a fork keeps exactly the coverage it
 # has today: the hosted `linux-fork` leg on placeholders, plus platforms, windows-tun,
@@ -38,13 +42,16 @@ permissions:
 # repositories" is all-or-nothing for the whole organisation.
 #
 # What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
-# of the job, and two things follow. The Docker jobs reap the container names before
-# themselves as well as after, because a cancelled run fires neither an EXIT trap nor an
-# `if: always()` step. And `anchor/bin` can finally be real: a runner that keeps a Go
-# toolchain and a module cache can check out anchor beside this and build it, which is
-# the thing docs/testing.md said "a runner has no way to fetch" for as long as CI ran on
-# machines that were thrown away. `service` and `integration` were `workflow_dispatch`
-# only for that reason alone, and they are not any more.
+# of the job, so the Docker jobs reap the container names before themselves as well as
+# after: a cancelled run fires neither an EXIT trap nor an `if: always()` step.
+#
+# What makes `service` and `integration` runnable at all, though, is not the machine --
+# it is the shelf. docs/testing.md said those two needed the real anchor binaries, which
+# "a runner has no way to fetch", and that was true only while the binaries had no
+# published source. They have one now: `make anchor-bins FETCH=1` downloads the pinned
+# release build from api.veilnet.com.au and verifies every digest, with no anchor
+# checkout and no credential. So both jobs lose their `workflow_dispatch` gate, and the
+# `linux` gate gets the real binaries too.
 #
 # And it is one machine. With a single runner process these four Linux jobs queue rather
 # than run side by side, so a push costs the sum of them instead of the longest — which
@@ -62,21 +69,9 @@ jobs:
     # on placeholders, which is what this job did for everyone before it had a machine.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
-
-    # Two checkouts side by side, so `anchor-bins` finds ../anchor where it already
-    # looks by default — the same layout docs/build.md documents for a developer. Every
-    # step below runs in the conflux one.
-    defaults:
-      run:
-        working-directory: conflux
-
     steps:
       - uses: actions/checkout@v7
-        with:
-          path: conflux
-      - uses: ./conflux/.github/actions/setup
-        with:
-          path: conflux
+      - uses: ./.github/actions/setup
 
       # The real binaries, which this job has never had. Eight tests gate on
       # anchor.Supported — a size check, so placeholders do not fool it — and every one
@@ -84,9 +79,7 @@ jobs:
       # checks in anchor/, the four libexec extraction tests, the anchorctl flag
       # cross-check, and the shadowing check in internal/cli. A skip is green, which is
       # why this was easy not to notice.
-      - uses: ./conflux/.github/actions/anchor-bins
-        with:
-          token: ${{ secrets.ANCHOR_READ_TOKEN }}
+      - uses: ./.github/actions/anchor-bins
 
       - run: make fmtcheck
       - run: make vet
@@ -261,25 +254,15 @@ jobs:
     # with no `anchor-bins` step before it, so //go:embed had nothing to embed and the
     # build failed before the size gate could say why.
     #
-    # Never for a fork's pull request: it wants the runner, the Docker socket and a token
-    # for a private repository, which is the combination the header refuses a fork.
+    # Never for a fork's pull request: it wants the runner and the Docker socket, which
+    # is a machine that survives the job running a stranger's code.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 20
-    defaults:
-      run:
-        working-directory: conflux
-
     steps:
       - uses: actions/checkout@v7
-        with:
-          path: conflux
-      - uses: ./conflux/.github/actions/setup
-        with:
-          path: conflux
-      - uses: ./conflux/.github/actions/anchor-bins
-        with:
-          token: ${{ secrets.ANCHOR_READ_TOKEN }}
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/anchor-bins
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh
@@ -302,20 +285,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: conflux
-
     steps:
       - uses: actions/checkout@v7
-        with:
-          path: conflux
-      - uses: ./conflux/.github/actions/setup
-        with:
-          path: conflux
-      - uses: ./conflux/.github/actions/anchor-bins
-        with:
-          token: ${{ secrets.ANCHOR_READ_TOKEN }}
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/anchor-bins
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+  # Callable, so release.yml can wait on the whole of this rather than on a copy of it.
+  # A tag push does not run the triggers above, so before this a release was gated on
+  # nothing at all -- the artifact check in release.yml is about the binaries it is
+  # about to embed, not about whether the code works.
+  workflow_call:
+
 permissions:
   contents: read
 
@@ -18,10 +24,11 @@ permissions:
 # macOS and Windows stay on GitHub's images, because there is no other machine here that
 # can run them.
 #
-# `docs` and `cross` stay on GitHub's Linux images. `docs` is two greps and `cross` is a
-# compile check that runs on placeholders by design, so neither needs anything the runner
-# has — and everything on the runner queues behind everything else, so moving them there
-# would cost the machine's time to buy nothing.
+# Only `service` and `integration` are on veilnet-dev, because only they need it: Docker,
+# a privileged container, a TUN device and a machine quiet enough that gossip timings mean
+# something. Everything else is hosted. `linux` in particular does not belong there — it
+# wants a Go toolchain and the anchor binaries, and since the binaries come from a public
+# shelf rather than a checkout of a private repository, any runner can have them.
 #
 # **This repository is public.** A self-hosted runner is a machine that survives the job,
 # and conflux has forks; `pull_request` runs the workflow from the *head* of the PR, so
@@ -35,11 +42,13 @@ permissions:
 # secrets to reach for -- but the guard stays, because running a stranger's code on a
 # persistent machine is worth refusing on its own.
 #
-# So every self-hosted job carries a fork guard, and a fork keeps exactly the coverage it
-# has today: the hosted `linux-fork` leg on placeholders, plus platforms, windows-tun,
-# cross and docs. Nothing a fork can write reaches this machine. The guard lives here
-# rather than in a setting because a setting cannot express it — "Allow public
-# repositories" is all-or-nothing for the whole organisation.
+# So the two jobs that do need the machine carry a fork guard. Everything else is hosted,
+# which is most of the suite: a fork's pull request gets the full Linux gate with the real
+# pinned binaries, cross, both platform legs, windows-tun and docs. What it does not get
+# is the two container suites, and nothing it can write reaches veilnet-dev.
+#
+# The guard lives here rather than in a setting because a setting cannot express it —
+# "Allow public repositories" is all-or-nothing for the whole organisation.
 #
 # What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
 # of the job, so the Docker jobs reap the container names before themselves as well as
@@ -65,10 +74,14 @@ concurrency:
 
 jobs:
   linux:
-    # Not for a pull request from a fork; see the header. `linux-fork` below covers those
-    # on placeholders, which is what this job did for everyone before it had a machine.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux]
+    # Hosted, and no fork guard, because this job wants nothing veilnet-dev has: no
+    # Docker, no TUN, no privileges -- a Go toolchain and the anchor binaries. It was on
+    # the runner only because the binaries used to need a checkout of a private
+    # repository, and the shelf is a public URL that any runner can fetch from.
+    #
+    # So a fork's pull request gets this gate in full, with the real pinned binaries,
+    # rather than the placeholder fallback it used to get from a second copy of the job.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -136,44 +149,6 @@ jobs:
           git diff --exit-code internal/anchorctl/testdata/ \
             || { echo "::error::argv changed; run 'make golden' and commit the fixtures"; exit 1; }
 
-  linux-fork:
-    # What `linux` was for everyone until this repository had a machine, kept for the one
-    # case that still cannot use it: a pull request from a fork.
-    #
-    # Placeholders, so the eight tests that need real binaries skip here and the assertion
-    # that they did not is absent -- there is nothing dishonest in that as long as the two
-    # jobs never both run, which the complementary conditions guarantee. A fork's change
-    # is still formatted, vetted, linted, tested under -race and checked against the argv
-    # fixtures, which is every gate that does not need an anchor.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup
-      - run: make anchor-bins
-
-      - run: make fmtcheck
-      - run: make vet
-      - run: make tidycheck
-
-      - name: staticcheck
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
-          staticcheck ./...
-
-      - name: govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
-          govulncheck ./...
-
-      - run: make race
-
-      - name: golden argv fixtures are current
-        run: |
-          make golden
-          git diff --exit-code internal/anchorctl/testdata/ \
-            || { echo "::error::argv changed; run 'make golden' and commit the fixtures"; exit 1; }
-
   cross:
     # Vets and compiles all seven targets. Deliberately on placeholders: this job asks
     # whether every target still builds, and `make anchor-bins` with no checkout answers
@@ -191,6 +166,13 @@ jobs:
       - run: make cross
 
   platforms:
+    # Nothing here runs until the gate has. If the code does not compile, does not
+    # pass vet, or fails its unit tests, the answer is the same on every platform and in
+    # every container -- so spending a macOS runner, a Windows runner and two privileged
+    # container suites to be told again is time bought for nothing.
+    #
+    needs: [linux, cross]
+    
     # macOS and Windows, on the operating system that has the path handling, the file
     # modes and the DACL logic. Linux is not a leg here: the `linux` job already runs
     # the same suite under -race, and `cross` vets every target.
@@ -211,6 +193,13 @@ jobs:
       - run: go test ./...
 
   windows-tun:
+    # Nothing here runs until the gate has. If the code does not compile, does not
+    # pass vet, or fails its unit tests, the answer is the same on every platform and in
+    # every container -- so spending a macOS runner, a Windows runner and two privileged
+    # container suites to be told again is time bought for nothing.
+    #
+    needs: [linux, cross]
+    
     # With placeholders the extraction tests skip, so this checks the wintun pin is
     # readable and that the build works on Windows. The extraction itself is covered on
     # Linux by the `linux` job above, which now has real binaries; there is no
@@ -256,6 +245,10 @@ jobs:
     #
     # Never for a fork's pull request: it wants the runner and the Docker socket, which
     # is a machine that survives the job running a stranger's code.
+    # Same gate as the platform jobs above, and the argument is stronger here: these
+    # two boot privileged containers, enrol against the live API and wait on gossip.
+    # Minutes, and three enrolments, to re-discover that a unit test was already red.
+    needs: [linux, cross]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 20
@@ -282,6 +275,10 @@ jobs:
     #
     # Never for a fork's pull request, for the reason `service` gives. This one also
     # enrols three times against the live API, which is not a thing to hand a stranger.
+    # Same gate as the platform jobs above, and the argument is stronger here: these
+    # two boot privileged containers, enrol against the live API and wait on gossip.
+    # Minutes, and three enrolments, to re-discover that a unit test was already red.
+    needs: [linux, cross]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,19 @@ permissions:
 # macOS and Windows stay on GitHub's images, because there is no other machine here that
 # can run them.
 #
-# Anything that can run on veilnet-dev does. `linux`, `cross`, `service` and `integration`
-# are all Linux work and all go there; macOS and Windows stay on GitHub's images because
-# there is no other machine here that can run them, and `docs` is two greps that would
-# spend a queue slot to save nothing.
+# Anything that can run on veilnet-dev does. It is Linux with Docker, Go, Python and Node,
+# so every Linux job here goes there -- `linux`, `cross`, `service`, `integration` and
+# `docs`. macOS and Windows stay on GitHub's images because nothing else here can run
+# them, and they are the whole reason `platforms` and `windows-tun` exist.
 #
-# `linux` and `cross` name their runner with an expression rather than a label, so that a
-# fork's pull request falls back to a hosted image instead of being refused the gate
-# altogether. `service` and `integration` cannot fall back -- they want Docker and a
-# privileged container on a machine that is not thrown away -- so a fork simply does not
-# get them.
+# Every one of them refuses a fork's pull request outright, and nothing stands in for
+# them. Since the platform jobs need the gate, a fork's pull request runs nothing at all.
+#
+# Deliberate rather than an oversight. A machine that survives the job does not run a
+# stranger's code, and the alternative -- a hosted copy of the gate for forks -- is a
+# second definition of the same thing, which is the arrangement this file had briefly and
+# is worse than the gap: one of the two is always skipped, so the one that rots is the one
+# nobody watches.
 #
 # **This repository is public.** A self-hosted runner is a machine that survives the job,
 # and conflux has forks; `pull_request` runs the workflow from the *head* of the PR, so
@@ -47,13 +50,9 @@ permissions:
 # secrets to reach for -- but the guard stays, because running a stranger's code on a
 # persistent machine is worth refusing on its own.
 #
-# Either way nothing a fork writes executes on veilnet-dev: the two container jobs refuse
-# it outright, and the two build jobs send it to a hosted image. It still gets the full
-# Linux gate with the real pinned binaries, cross, both platform legs, windows-tun and
-# docs -- everything but the container suites.
-#
-# This lives here rather than in a setting because a setting cannot express it — "Allow
-# public repositories" is all-or-nothing for the whole organisation.
+# So nothing a fork writes executes on veilnet-dev at all. This lives here rather than in
+# a setting because a setting cannot express it — "Allow public repositories" is
+# all-or-nothing for the whole organisation.
 #
 # What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
 # of the job, so the Docker jobs reap the container names before themselves as well as
@@ -79,19 +78,13 @@ concurrency:
 
 jobs:
   linux:
-    # veilnet-dev, except for a fork's pull request, which falls back to a GitHub image.
-    #
-    # The expression is doing what a second job used to. A fork cannot be allowed onto a
-    # machine that survives the job, but it still needs this gate -- so the choice is
-    # between two near-identical jobs with complementary conditions, or one job that
-    # picks its runner. anchor's `tun` matrix already carries a runner for the same
-    # reason, and one definition cannot drift from itself.
-    #
-    # The fallback costs a fork nothing now: the anchor binaries come from a public
-    # shelf rather than a checkout of a private repository, so a hosted runner fetches
-    # exactly what this one does. The duplicate job that preceded this could not, and
-    # gave forks placeholders.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "linux"]') || 'ubuntu-latest' }}
+    # Not for a fork's pull request, and with nothing standing in for it. A fork does not
+    # get the Linux gate, which means -- since everything below needs this job -- that a
+    # fork's pull request runs `docs` and stops. That is the deliberate position: a
+    # machine that survives the job does not run a stranger's code, and a gate worth
+    # having on a hosted image would be a second definition of this one.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -165,8 +158,9 @@ jobs:
     # that for the price of fourteen two-line files. The size gate is `make dist`, which
     # the two container jobs run with the real thing.
     #
-    # Same runner rule as `linux` above, and the same reason for the fallback.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "linux"]') || 'ubuntu-latest' }}
+    # Same rule as `linux` above.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -305,7 +299,12 @@ jobs:
         run: docker rm -f cfx-a cfx-b cfx-c || true
 
   docs:
-    runs-on: ubuntu-latest
+    # On the runner like everything else that can be. Two greps, so this is the one job
+    # where the queue slot costs more than the work -- and consistency is worth more than
+    # three seconds, because "everything Linux runs on our machine" is a rule somebody can
+    # check, and "everything except the cheap ones" is a judgement call that drifts.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,16 +93,29 @@ jobs:
       # Now that the binaries are real, say so if they stop being. A skip is green, and
       # the eight tests above would go back to skipping silently the day this job lost
       # its anchor checkout — which is exactly the state it was in before this change.
+      # Any skip at all, and not a grep for the reason. `go test -v` prints the reason
+      # on the line *before* `--- SKIP:`, so a pattern wanting both on one line matches
+      # nothing and the gate passes on exactly the state it exists to catch. Checked in
+      # both directions before this was committed: it fails with placeholders in
+      # anchor/bin and passes with real ones.
+      #
+      # Nothing in these four packages skips for any other reason on Linux, so zero is
+      # the right number and a new legitimate skip should have to come and argue here.
       - name: the tests that need real binaries actually ran
         run: |
           set -euo pipefail
           out=$(go test -v -count=1 ./anchor/ ./internal/libexec/ ./internal/anchorctl/ ./internal/cli/)
-          if printf '%s\n' "$out" | grep -E 'SKIP.*no anchor pair'; then
-            echo "::error::a test skipped for want of anchor binaries in the job that provides them" >&2
+          if printf '%s\n' "$out" | grep -q -- '--- SKIP'; then
+            echo "::error::a test skipped in the job that provides the anchor binaries" >&2
+            printf '%s\n' "$out" | grep -B1 -- '--- SKIP' >&2
             exit 1
           fi
-          printf '%s\n' "$out" | grep -cE '^(=== RUN|--- PASS)' >/dev/null
-          echo "the binary-dependent tests ran"
+          ran=$(printf '%s\n' "$out" | grep -c -- '--- PASS')
+          [ "$ran" -ge 30 ] || {
+            echo "::error::only $ran tests ran here; this gate is meant to cover four packages" >&2
+            exit 1
+          }
+          echo "$ran tests ran, none skipped"
 
       # The argv fixtures must match what the code produces. A change to what conflux
       # passes anchorctl is a reviewable text diff or it is a bug.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,16 @@ permissions:
 # macOS and Windows stay on GitHub's images, because there is no other machine here that
 # can run them.
 #
-# Only `service` and `integration` are on veilnet-dev, because only they need it: Docker,
-# a privileged container, a TUN device and a machine quiet enough that gossip timings mean
-# something. Everything else is hosted. `linux` in particular does not belong there — it
-# wants a Go toolchain and the anchor binaries, and since the binaries come from a public
-# shelf rather than a checkout of a private repository, any runner can have them.
+# Anything that can run on veilnet-dev does. `linux`, `cross`, `service` and `integration`
+# are all Linux work and all go there; macOS and Windows stay on GitHub's images because
+# there is no other machine here that can run them, and `docs` is two greps that would
+# spend a queue slot to save nothing.
+#
+# `linux` and `cross` name their runner with an expression rather than a label, so that a
+# fork's pull request falls back to a hosted image instead of being refused the gate
+# altogether. `service` and `integration` cannot fall back -- they want Docker and a
+# privileged container on a machine that is not thrown away -- so a fork simply does not
+# get them.
 #
 # **This repository is public.** A self-hosted runner is a machine that survives the job,
 # and conflux has forks; `pull_request` runs the workflow from the *head* of the PR, so
@@ -42,13 +47,13 @@ permissions:
 # secrets to reach for -- but the guard stays, because running a stranger's code on a
 # persistent machine is worth refusing on its own.
 #
-# So the two jobs that do need the machine carry a fork guard. Everything else is hosted,
-# which is most of the suite: a fork's pull request gets the full Linux gate with the real
-# pinned binaries, cross, both platform legs, windows-tun and docs. What it does not get
-# is the two container suites, and nothing it can write reaches veilnet-dev.
+# Either way nothing a fork writes executes on veilnet-dev: the two container jobs refuse
+# it outright, and the two build jobs send it to a hosted image. It still gets the full
+# Linux gate with the real pinned binaries, cross, both platform legs, windows-tun and
+# docs -- everything but the container suites.
 #
-# The guard lives here rather than in a setting because a setting cannot express it —
-# "Allow public repositories" is all-or-nothing for the whole organisation.
+# This lives here rather than in a setting because a setting cannot express it — "Allow
+# public repositories" is all-or-nothing for the whole organisation.
 #
 # What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
 # of the job, so the Docker jobs reap the container names before themselves as well as
@@ -74,14 +79,19 @@ concurrency:
 
 jobs:
   linux:
-    # Hosted, and no fork guard, because this job wants nothing veilnet-dev has: no
-    # Docker, no TUN, no privileges -- a Go toolchain and the anchor binaries. It was on
-    # the runner only because the binaries used to need a checkout of a private
-    # repository, and the shelf is a public URL that any runner can fetch from.
+    # veilnet-dev, except for a fork's pull request, which falls back to a GitHub image.
     #
-    # So a fork's pull request gets this gate in full, with the real pinned binaries,
-    # rather than the placeholder fallback it used to get from a second copy of the job.
-    runs-on: ubuntu-latest
+    # The expression is doing what a second job used to. A fork cannot be allowed onto a
+    # machine that survives the job, but it still needs this gate -- so the choice is
+    # between two near-identical jobs with complementary conditions, or one job that
+    # picks its runner. anchor's `tun` matrix already carries a runner for the same
+    # reason, and one definition cannot drift from itself.
+    #
+    # The fallback costs a fork nothing now: the anchor binaries come from a public
+    # shelf rather than a checkout of a private repository, so a hosted runner fetches
+    # exactly what this one does. The duplicate job that preceded this could not, and
+    # gave forks placeholders.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "linux"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -155,10 +165,8 @@ jobs:
     # that for the price of fourteen two-line files. The size gate is `make dist`, which
     # the two container jobs run with the real thing.
     #
-    # Hosted, therefore, and for every event including a fork's: it wants a Go toolchain
-    # and nothing else, so putting it on the one runner would lengthen that queue to buy
-    # nothing and would cost forks the check entirely.
-    runs-on: ubuntu-latest
+    # Same runner rule as `linux` above, and the same reason for the fallback.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "linux"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,40 +9,103 @@ on:
 permissions:
   contents: read
 
+# Where these run.
+#
+# Every Linux job is on `[self-hosted, linux]` — veilnet-dev, which has Docker, Go, Node
+# and Python, and which anchor's CI has been running on since its PR #15. Two labels and
+# not a third: the runner's *name* is not a label unless somebody registered it as one,
+# and a `runs-on` naming a label that does not exist does not fail, it queues for ever.
+# macOS and Windows stay on GitHub's images, because there is no other machine here that
+# can run them.
+#
+# `docs` is the one Linux job that does not move. It is two greps, it needs neither Go
+# nor Docker nor anything else the runner has, and everything on the runner queues — so
+# putting it there would cost the machine's time to buy nothing.
+#
+# What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
+# of the job, and two things follow. The Docker jobs reap the container names before
+# themselves as well as after, because a cancelled run fires neither an EXIT trap nor an
+# `if: always()` step. And `anchor/bin` can finally be real: a runner that keeps a Go
+# toolchain and a module cache can check out anchor beside this and build it, which is
+# the thing docs/testing.md said "a runner has no way to fetch" for as long as CI ran on
+# machines that were thrown away. `service` and `integration` were `workflow_dispatch`
+# only for that reason alone, and they are not any more.
+#
+# And it is one machine. With a single runner process these four Linux jobs queue rather
+# than run side by side, so a push costs the sum of them instead of the longest — which
+# makes the cancellation below matter more than it did, not less: a superseded run holds
+# the machine the run that replaced it is waiting for. Do not register a second runner
+# process to win that back; anchor/docs/ci.md records the measurement that argues against
+# it. More parallelism wants a second machine, not a second process.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
+    runs-on: [self-hosted, linux]
 
-      # anchor/bin is not in git. With no anchor checkout this writes placeholders,
-      # which compile -- enough for everything in this job, and not enough to
-      # produce a shippable binary, which `make dist` refuses separately.
-      - run: make anchor-bins
+    # Two checkouts side by side, so `anchor-bins` finds ../anchor where it already
+    # looks by default — the same layout docs/build.md documents for a developer. Every
+    # step below runs in the conflux one.
+    defaults:
+      run:
+        working-directory: conflux
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: conflux
+      - uses: ./conflux/.github/actions/setup
+        with:
+          path: conflux
+
+      # The real binaries, which this job has never had. Eight tests gate on
+      # anchor.Supported — a size check, so placeholders do not fool it — and every one
+      # of them has been skipping on every run since the suite was written: both header
+      # checks in anchor/, the four libexec extraction tests, the anchorctl flag
+      # cross-check, and the shadowing check in internal/cli. A skip is green, which is
+      # why this was easy not to notice.
+      - uses: ./conflux/.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_READ_TOKEN }}
 
       - run: make fmtcheck
       - run: make vet
       - run: make tidycheck
 
+      # Pinned rather than @latest. On a machine that is thrown away, @latest costs a
+      # download; on one that is not, it also means the version that gates this repo
+      # changes underneath it without a commit, and a new check arrives as a red build
+      # on somebody else's unrelated pull request.
       - name: staticcheck
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
           staticcheck ./...
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
           govulncheck ./...
 
       - run: make race
 
-      # The argv fixtures must match what the code produces. A change to what
-      # conflux passes anchorctl is a reviewable text diff or it is a bug.
+      # Now that the binaries are real, say so if they stop being. A skip is green, and
+      # the eight tests above would go back to skipping silently the day this job lost
+      # its anchor checkout — which is exactly the state it was in before this change.
+      - name: the tests that need real binaries actually ran
+        run: |
+          set -euo pipefail
+          out=$(go test -v -count=1 ./anchor/ ./internal/libexec/ ./internal/anchorctl/ ./internal/cli/)
+          if printf '%s\n' "$out" | grep -E 'SKIP.*no anchor pair'; then
+            echo "::error::a test skipped for want of anchor binaries in the job that provides them" >&2
+            exit 1
+          fi
+          printf '%s\n' "$out" | grep -cE '^(=== RUN|--- PASS)' >/dev/null
+          echo "the binary-dependent tests ran"
+
+      # The argv fixtures must match what the code produces. A change to what conflux
+      # passes anchorctl is a reviewable text diff or it is a bug.
       - name: golden argv fixtures are current
         run: |
           make golden
@@ -50,16 +113,15 @@ jobs:
             || { echo "::error::argv changed; run 'make golden' and commit the fixtures"; exit 1; }
 
   cross:
-    # Vets and compiles all seven targets. Artifacts and the size gate are `make
-    # dist`, which needs the real anchor binaries -- see the note on `service` below.
-    runs-on: ubuntu-latest
+    # Vets and compiles all seven targets. Deliberately on placeholders: this job asks
+    # whether every target still builds, and `make anchor-bins` with no checkout answers
+    # that for the price of fourteen two-line files. The size gate is `make dist`, which
+    # the two jobs below run with the real thing.
+    runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: make anchor-bins
-
-      # cross vets all seven targets. The size gate in dist needs real binaries, so
-      # with placeholders this checks compilation and stops short of the artifacts.
       - run: make cross
 
   platforms:
@@ -76,7 +138,7 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: make anchor-bins
       - run: go build ./...
@@ -84,11 +146,12 @@ jobs:
 
   windows-tun:
     # With placeholders the extraction tests skip, so this checks the wintun pin is
-    # readable and that the build works on Windows. The extraction itself is covered
-    # locally, where real binaries exist.
+    # readable and that the build works on Windows. The extraction itself is covered on
+    # Linux by the `linux` job above, which now has real binaries; there is no
+    # self-hosted Windows machine to give this one the same.
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: make anchor-bins
         shell: bash
@@ -119,72 +182,73 @@ jobs:
     # container is the reboot, and this is the only way to check the property that
     # matters most: a machine that was up before is up again with nothing typed.
     #
-    # Manual only. It needs the real anchor binaries, and they are not in git and not
-    # fetchable from here -- so a runner has no way to get them. Run it locally with
-    # `make anchor-bins && make dist` first, or enable it once anchor/bin has a
-    # source CI can reach. See docs/build.md.
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    # It ran on no push and no pull request until now — `workflow_dispatch` only,
+    # because it needs the real anchor binaries and a hosted runner had no way to get
+    # them. It also could not have worked on a dispatch: it went straight to `make dist`
+    # with no `anchor-bins` step before it, so //go:embed had nothing to embed and the
+    # build failed before the size gate could say why.
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: conflux
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
+      - uses: actions/checkout@v7
+        with:
+          path: conflux
+      - uses: ./conflux/.github/actions/setup
+        with:
+          path: conflux
+      - uses: ./conflux/.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_READ_TOKEN }}
 
-      - run: make dist
-      - run: cp dist/conflux-linux-amd64 test/systemd/conflux
-      - run: docker build -t conflux-systemd-test test/systemd
+      - name: what this runner gives the suite
+        run: ./test/preflight.sh
 
-      - name: install registers without inventing a configuration
-        run: |
-          docker run -d --name cfx --privileged --cgroupns=host \
-            -v /sys/fs/cgroup:/sys/fs/cgroup:rw --device /dev/net/tun conflux-systemd-test
-          for i in $(seq 30); do
-            [ "$(docker exec cfx systemctl is-system-running 2>/dev/null)" = running ] && break
-            sleep 1
-          done
-
-          docker exec cfx conflux install
-          [ "$(docker exec cfx systemctl is-enabled conflux.service)" = enabled ] \
-            || { echo "::error::install did not enable the unit"; exit 1; }
-          [ "$(docker exec cfx systemctl is-active conflux.service)" = inactive ] \
-            || { echo "::error::install started the service; it must only register"; exit 1; }
-
-      - name: uninstall leaves nothing
-        run: |
-          docker exec cfx conflux uninstall --yes
-          docker exec cfx sh -c 'test ! -f /etc/systemd/system/conflux.service' \
-            || { echo "::error::the unit file survived uninstall"; exit 1; }
-          docker exec cfx sh -c 'test ! -d /var/lib/conflux' \
-            || { echo "::error::the state directory survived uninstall"; exit 1; }
+      - name: install registers, uninstall leaves nothing
+        run: make service-test
 
       - if: always()
         run: docker rm -f cfx || true
 
   integration:
-    # The real thing, against the live API: two nodes, one taint, pinging each other.
+    # The real thing, against the live API: three nodes, one taint, reaching each other
+    # over the overlay, surviving a reboot, and the LAN-discovery control.
     #
-    # Manual only, for the same reason as `service` -- it needs the real anchor
-    # binaries. Locally this is `./test/integration.sh`, which is what it runs.
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Manual-only for the same reason as `service`, and no longer. Locally this is
+    # `make integration`, which is what it runs.
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: conflux
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
+      - uses: actions/checkout@v7
+        with:
+          path: conflux
+      - uses: ./conflux/.github/actions/setup
+        with:
+          path: conflux
+      - uses: ./conflux/.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_READ_TOKEN }}
 
-      - run: make dist
-      - run: cp dist/conflux-linux-amd64 test/systemd/conflux
-      - run: docker build -t conflux-systemd-test test/systemd
+      - name: what this runner gives the suite
+        run: ./test/preflight.sh
 
-      - name: two nodes, one taint, reachable both ways
-        run: ./test/integration.sh
+      - name: three nodes, one taint, reachable both ways
+        run: make integration
 
       - if: always()
-        run: docker rm -f cfx-a cfx-b || true
+        run: docker rm -f cfx-a cfx-b cfx-c || true
 
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: every docs page is linked from the README, and exists
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,24 @@ permissions:
 # macOS and Windows stay on GitHub's images, because there is no other machine here that
 # can run them.
 #
-# `docs` is the one Linux job that does not move. It is two greps, it needs neither Go
-# nor Docker nor anything else the runner has, and everything on the runner queues — so
-# putting it there would cost the machine's time to buy nothing.
+# `docs` and `cross` stay on GitHub's Linux images. `docs` is two greps and `cross` is a
+# compile check that runs on placeholders by design, so neither needs anything the runner
+# has — and everything on the runner queues behind everything else, so moving them there
+# would cost the machine's time to buy nothing.
+#
+# **This repository is public, and anchor is not.** That asymmetry is the whole of the
+# fork rule below. A self-hosted runner is a machine that survives the job, and conflux
+# has forks; `pull_request` runs the workflow from the *head* of the PR, so a fork could
+# otherwise propose a workflow that runs its own code on veilnet-dev, beside a Docker
+# socket and a token that reads a private repository. That is what GitHub's warning on
+# the "Allow public repositories" checkbox is about, and why that checkbox exists
+# separately from repository access at all.
+#
+# So every self-hosted job carries a fork guard, and a fork keeps exactly the coverage it
+# has today: the hosted `linux-fork` leg on placeholders, plus platforms, windows-tun,
+# cross and docs. Nothing a fork can write reaches this machine. The guard lives here
+# rather than in a setting because a setting cannot express it — "Allow public
+# repositories" is all-or-nothing for the whole organisation.
 #
 # What the machine changes, beyond the label. It is not a fresh VM destroyed at the end
 # of the job, and two things follow. The Docker jobs reap the container names before
@@ -43,6 +58,9 @@ concurrency:
 
 jobs:
   linux:
+    # Not for a pull request from a fork; see the header. `linux-fork` below covers those
+    # on placeholders, which is what this job did for everyone before it had a machine.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
 
     # Two checkouts side by side, so `anchor-bins` finds ../anchor where it already
@@ -125,12 +143,54 @@ jobs:
           git diff --exit-code internal/anchorctl/testdata/ \
             || { echo "::error::argv changed; run 'make golden' and commit the fixtures"; exit 1; }
 
+  linux-fork:
+    # What `linux` was for everyone until this repository had a machine, kept for the one
+    # case that still cannot use it: a pull request from a fork.
+    #
+    # Placeholders, so the eight tests that need real binaries skip here and the assertion
+    # that they did not is absent -- there is nothing dishonest in that as long as the two
+    # jobs never both run, which the complementary conditions guarantee. A fork's change
+    # is still formatted, vetted, linted, tested under -race and checked against the argv
+    # fixtures, which is every gate that does not need an anchor.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: make anchor-bins
+
+      - run: make fmtcheck
+      - run: make vet
+      - run: make tidycheck
+
+      - name: staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
+          staticcheck ./...
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
+          govulncheck ./...
+
+      - run: make race
+
+      - name: golden argv fixtures are current
+        run: |
+          make golden
+          git diff --exit-code internal/anchorctl/testdata/ \
+            || { echo "::error::argv changed; run 'make golden' and commit the fixtures"; exit 1; }
+
   cross:
     # Vets and compiles all seven targets. Deliberately on placeholders: this job asks
     # whether every target still builds, and `make anchor-bins` with no checkout answers
     # that for the price of fourteen two-line files. The size gate is `make dist`, which
-    # the two jobs below run with the real thing.
-    runs-on: [self-hosted, linux]
+    # the two container jobs run with the real thing.
+    #
+    # Hosted, therefore, and for every event including a fork's: it wants a Go toolchain
+    # and nothing else, so putting it on the one runner would lengthen that queue to buy
+    # nothing and would cost forks the check entirely.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -200,6 +260,10 @@ jobs:
     # them. It also could not have worked on a dispatch: it went straight to `make dist`
     # with no `anchor-bins` step before it, so //go:embed had nothing to embed and the
     # build failed before the size gate could say why.
+    #
+    # Never for a fork's pull request: it wants the runner, the Docker socket and a token
+    # for a private repository, which is the combination the header refuses a fork.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 20
     defaults:
@@ -232,6 +296,10 @@ jobs:
     #
     # Manual-only for the same reason as `service`, and no longer. Locally this is
     # `make integration`, which is what it runs.
+    #
+    # Never for a fork's pull request, for the reason `service` gives. This one also
+    # enrols three times against the live API, which is not a thing to hand a stranger.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux]
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Everything ci.yml checks, before anything here ships.
+  #
+  # A tag push runs none of ci.yml's own triggers, so until this a release was gated on
+  # nothing: `verify` below asks whether the binaries about to be embedded are real, and
+  # nothing asked whether the code around them still worked. The tag is usually cut from
+  # a commit that was green on main, which is a convention rather than a check -- and the
+  # one release where it is not true is the one nobody wants to find out about from a
+  # user.
+  #
+  # Calling ci.yml rather than repeating its steps: a second copy of the gate is a copy
+  # that drifts, and the half that drifts is always the one nobody is watching.
+  tests:
+    uses: ./.github/workflows/ci.yml
+
   verify:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # anchoradmin can mint realm roots. Shipping it inside conflux would hand that
       # to every user, so its absence is checked rather than assumed.
@@ -63,7 +78,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - run: make dist VERSION=${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,25 @@ jobs:
 
   verify:
     needs: tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
 
+      # The binaries this release is about to embed, fetched from the shelf.
+      #
+      # Without this the job could not run at all: anchor/bin is not in git, so a fresh
+      # checkout has none and the very next step failed on its own message -- "a release
+      # runner needs a source for them". That source exists now, which is the whole of
+      # what made a conflux release possible from CI rather than from a laptop.
+      - uses: ./.github/actions/anchor-bins
+
+      # A second opinion on what the fetcher just wrote. It already refuses anchoradmin,
+      # verifies every digest, and fails rather than falling back -- so these three now
+      # assert what should already be true. Kept because this is the last gate before
+      # bytes go to the public, and a check that costs a second is worth more here than
+      # the argument for removing it.
+      #
       # anchoradmin can mint realm roots. Shipping it inside conflux would hand that
       # to every user, so its absence is checked rather than assumed.
       - name: no anchoradmin is ever shipped
@@ -76,11 +91,20 @@ jobs:
 
   build:
     needs: verify
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
+      # Again, because a job is a fresh checkout and anchor/bin is not in git. The
+      # fetcher pins nothing of its own -- it takes what the shelf serves now -- so a
+      # release carries whatever anchor published most recently, which is the intent:
+      # conflux ships the newest anchor, not a remembered one.
+      - uses: ./.github/actions/anchor-bins
+
+      # All seven targets, not just this runner's: linux amd64 and arm64, darwin arm64,
+      # windows amd64 and arm64, freebsd and openbsd. CGO_ENABLED=0 throughout, so one
+      # Linux machine cross-builds every one of them.
       - run: make dist VERSION=${{ github.ref_name }}
 
       - uses: actions/attest-build-provenance@v1

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ anchor/bin/
 
 # The conflux copied into the systemd test image by `make dist && cp`.
 /test/systemd/conflux
+
+# `go build ./cmd/...` drops this at the repo root.
+/anchor-fetch

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ MAX_MB := 75
 
 ANCHOR_SRC ?= ../anchor
 
-.PHONY: all anchor-bins build test race vet fmt fmtcheck lint vulncheck tidycheck golden cross dist clean help
+# The tag `make image` builds and the two suites run. Overridable so a second checkout
+# on one machine does not race the first for the name.
+IMAGE ?= conflux-systemd-test
+
+.PHONY: all anchor-bins build test race vet fmt fmtcheck lint vulncheck tidycheck golden cross dist image service-test integration clean help
 
 all: fmtcheck vet lint tidycheck test cross dist
 
@@ -137,8 +141,31 @@ dist:
 	@cd $(DIST) && (sha256sum conflux-* > SHA256SUMS 2>/dev/null || shasum -a 256 conflux-* > SHA256SUMS)
 	@echo "  wrote $(DIST)/SHA256SUMS"
 
+# The systemd test image, and the two suites that run in it.
+#
+# Both existed only as a recipe in docs/testing.md and a copy of the same three lines
+# in ci.yml, which is two places for one sequence to drift. They are targets now so
+# CI runs what a developer runs -- `make integration` on a laptop and on veilnet-dev
+# are the same command.
+#
+# Docker, /dev/net/tun, cgroup v2 and real anchor binaries, so this is deliberately
+# not in `make all`.
+image: dist
+	@cp $(DIST)/conflux-linux-amd64 test/systemd/conflux
+	@docker build -q -t $(IMAGE) test/systemd >/dev/null
+	@echo "  built $(IMAGE) from $(DIST)/conflux-linux-amd64"
+
+# The boot service on its own: install registers without starting, uninstall leaves
+# nothing. Cheaper than `integration` and it enrols nothing, so it is the one to run
+# when the question is only about the unit.
+service-test: image
+	@IMAGE=$(IMAGE) ./test/service.sh
+
+integration: image
+	@IMAGE=$(IMAGE) ./test/integration.sh
+
 clean:
-	rm -rf $(BIN) $(DIST)
+	rm -rf $(BIN) $(DIST) test/systemd/conflux
 
 help:
 	@echo "conflux"
@@ -151,4 +178,7 @@ help:
 	@echo "  make dist        build all 8 into $(DIST)/ with SHA256SUMS and the size gate"
 	@echo "                   (needs real binaries: make anchor-bins first)"
 	@echo "  make golden      rewrite the argv fixtures after an intended change"
+	@echo "  make image       build the systemd test image from $(DIST)/conflux-linux-amd64"
+	@echo "  make service-test  install and uninstall in a container that boots systemd"
+	@echo "  make integration   three nodes, one taint, over the real API (needs Docker)"
 	@echo "  make all         everything CI runs"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ MAX_MB := 75
 
 ANCHOR_SRC ?= ../anchor
 
+# FETCH=1 downloads the pinned binaries from the shelf when no local anchor build is
+# available. Opt-in for now: the macOS and Windows jobs run anchor-bins too and need
+# only the two files their own build tag names, so fetching all fourteen there would
+# move 284 MB to compile 43.
+FETCH ?= 0
+SHELF_URL ?=
+
 # The tag `make image` builds and the two suites run. Overridable so a second checkout
 # on one machine does not race the first for the name.
 IMAGE ?= conflux-systemd-test
@@ -41,10 +48,14 @@ all: fmtcheck vet lint tidycheck test cross dist
 
 # anchor-bins puts the anchor binaries where //go:embed can find them. They are not in
 # git -- fourteen release builds are about 284 MB -- so a fresh clone runs this once
-# before its first build. With no anchor checkout it writes placeholders, which
+# before its first build.
+#
+# Three sources in order: a local release/ (pinned), a local dist/ (unpinned, taken
+# loudly), then with FETCH=1 the published shelf, which serves the pinned build and
+# needs no checkout and no credential. With none of them it writes placeholders, which
 # compile and are caught by the size gate in dist.
 anchor-bins:
-	@ANCHOR_SRC=$(ANCHOR_SRC) ./scripts/anchor-bins.sh
+	@ANCHOR_SRC=$(ANCHOR_SRC) FETCH=$(FETCH) SHELF_URL=$(SHELF_URL) ./scripts/anchor-bins.sh
 
 # CGO_ENABLED=0 here for the same reason cross and dist set it: so that the binary a
 # developer builds and installs is the same *kind* of binary as the one that ships.
@@ -169,8 +180,9 @@ clean:
 
 help:
 	@echo "conflux"
-	@echo "  make anchor-bins populate anchor/bin from a local anchor checkout (do this first)"
+	@echo "  make anchor-bins populate anchor/bin (do this first)"
 	@echo "                   ANCHOR_SRC=/path/to/anchor, default ../anchor"
+	@echo "                   FETCH=1 to download the pinned binaries instead, no checkout needed"
 	@echo "  make build       build for this machine"
 	@echo "  make test        run the tests"
 	@echo "  make race        run them under the race detector"

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ reaches the realm over — the host's IP network by default, or a link named by
 
 | Command | What it does |
 |---|---|
-| `conflux up [--taint T] [--ipv4 PREFIX \| --no-ipv4] [--subnet CIDR]... [--uplink DEV \| --no-uplink] [--peers HOST:PORT]` | enrol if needed, start in TUN mode, register the boot service |
-| `conflux proxy PORT[/NETWORK]=BACKEND ... [--taint T] [--uplink DEV] [--peers HOST:PORT]` | enrol if needed, start in userspace mode serving those backends |
+| `conflux up [--taint T] [--ipv4 PREFIX \| --no-ipv4] [--subnet CIDR]... [--uplink DEV \| --no-uplink] [--peers HOST:PORT] [--lan-discovery yes\|no\|auto]` | enrol if needed, start in TUN mode, register the boot service |
+| `conflux proxy PORT[/NETWORK]=BACKEND ... [--taint T] [--uplink DEV] [--peers HOST:PORT] [--lan-discovery yes\|no\|auto]` | enrol if needed, start in userspace mode serving those backends |
 | `conflux down` | stop the anchor now; the boot service and the configuration stay |
 | `conflux start` | start it again now, from the configuration already on disk |
 | `conflux renew` | fetch a fresh credential and install it on the running anchor, hot |

--- a/cmd/anchor-fetch/main.go
+++ b/cmd/anchor-fetch/main.go
@@ -1,0 +1,54 @@
+// Command anchor-fetch populates anchor/bin from the published release manifest.
+//
+// Invoked by scripts/anchor-bins.sh when no local anchor checkout is available, which
+// is the state CI is in and the state a fresh clone starts in.
+//
+// Go rather than shell, and a program rather than curl piped into a JSON parser,
+// because docs/build.md promises "Go 1.27.1 or newer, and nothing else" and a fresh
+// clone should not need python or jq to become buildable. It also puts the digest
+// check, the redirect refusal and the atomic write somewhere they can be tested.
+//
+// Deliberately imports no package that embeds anything. `go run ./cmd/anchor-fetch`
+// has to work when anchor/bin is empty -- that is the only moment it is ever wanted --
+// so a dependency on the anchor package would make this unable to run in exactly the
+// case it exists for.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/veil-net/conflux/internal/shelf"
+)
+
+func main() {
+	url := flag.String("url", shelf.DefaultURL, "the release manifest to fetch from")
+	dest := flag.String("dest", "anchor/bin", "where to write the binaries")
+	want := flag.String("want", "", "comma-separated file names to fetch (required)")
+
+	flag.Parse()
+
+	names := strings.FieldsFunc(*want, func(r rune) bool { return r == ',' })
+	if len(names) == 0 {
+		fmt.Fprintln(os.Stderr, "anchor-fetch: -want is required and names the files to fetch")
+		os.Exit(2)
+	}
+
+	// Interruptible, because this moves a couple of hundred megabytes and the first
+	// thing anybody does to a fetch that is taking too long is press ^C.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	log := func(format string, a ...any) { fmt.Fprintf(os.Stderr, "anchor-fetch: "+format+"\n", a...) }
+
+	if err := shelf.Fetch(ctx, *url, names, *dest, log); err != nil {
+		fmt.Fprintf(os.Stderr, "anchor-fetch: %v\n", err)
+		os.Exit(1)
+	}
+
+	log("%d/%d fetched, digests verified", len(names), len(names))
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -22,10 +22,12 @@ refreshed. So `anchor/bin/` is ignored, and a build populates it:
 ```console
 $ make anchor-bins                              # from ../anchor
 $ make anchor-bins ANCHOR_SRC=/path/to/anchor   # from somewhere else
+$ make anchor-bins FETCH=1                      # from the shelf; no checkout needed
 anchor-bins: 14/14 copied from ../anchor/release (release)
 ```
 
-The script looks for `release/` first and falls back to `dist/`. Those are not
+The script looks for `release/` first, falls back to `dist/`, and with `FETCH=1` falls
+back again to the published shelf. Those are not
 interchangeable: `release/` is the pinned, garbled build users get, and `dist/` is the
 unpinned development cross-build, which will join **any** realm tree. A conflux built
 from `dist/` is fine for development and wrong for anything shipped, and the script
@@ -34,6 +36,44 @@ says so loudly when it uses one.
 `anchoradmin` sits beside the other two in `release/` and is deliberately never
 copied. It can mint realm roots, and anything in `anchor/bin` is a candidate for being
 embedded into every conflux a user runs. The release workflow fails on its presence.
+
+### The shelf
+
+`make anchor-bins FETCH=1` fetches the **pinned** build from
+`https://api.veilnet.com.au/anchor/release`, with no anchor checkout and no credential:
+
+```console
+$ make anchor-bins FETCH=1
+anchor-fetch: shelf:   https://api.veilnet.com.au/anchor/release
+anchor-fetch: realm:   realmtglwuedqqa33e364nv73p46jk3kwi67lxjmnntz2mv3mb3mklasq
+anchor-fetch:   ok   anchord-linux-amd64           28.0 MB  95ca77b697e5
+  …
+anchor-fetch: 14/14 fetched, digests verified
+```
+
+`SHELF_URL=` points it elsewhere. The fetcher is `cmd/anchor-fetch` over
+`internal/shelf` — Go rather than curl and a JSON parser, because the promise at the top
+of this page is "Go 1.27.1 or newer, and nothing else", and a fresh clone should not have
+to acquire anything else to become buildable.
+
+What it refuses, and why each is worth a refusal:
+
+| | |
+|---|---|
+| a digest that does not match | the failure no later gate catches — a real binary of the right size passes the size gate, and one of the right architecture passes `TestPairIsRealExecutables` |
+| `anchoradmin` on the shelf | it mints realm roots, and every file in `anchor/bin` is a candidate for being embedded into every conflux a user runs |
+| a per-binary `url` on another host | the digest catches substituted content; this catches being sent somewhere conflux was never told about |
+| a manifest with no `pin` | nothing then says which realm these binaries are for |
+| an unknown `formatVersion` | a future shape may mean anything, so it is refused rather than guessed at |
+| a short body, or plain http | a truncated download, and an unencrypted one |
+
+A rejected download is never renamed into place, so a failed fetch leaves what was there
+before rather than a half-written binary.
+
+**`FETCH=1` is opt-in for now.** The macOS and Windows CI jobs run `anchor-bins` too and
+need only the two files their own build tag names, so fetching all fourteen there would
+move 284 MB to compile 43. Once the shelf serves every target and per-target narrowing
+exists, the default is one line to flip.
 
 ### A clone with no anchor checkout
 
@@ -76,21 +116,23 @@ reached 840 MB from a single commit.
 an `anchord` that is not one — failing at exec on a user's machine rather than at build
 time here.
 
-**Building it in CI** is what the runner does, and it is not a substitute for either.
-`make dist` needs only Go, so a machine that keeps a checkout can produce the fourteen
-on every push — but they are unpinned, which is fine for testing against a live realm
-and wrong for anything shipped. Note the trap if you automate this anywhere else:
-anchor's `make release` depends on `genesis/genesis.pin`, and with no `genesis/`
-directory its rule **mints a new genesis root** instead of failing. The resulting
-binaries enrol perfectly and never handshake. The CI action refuses to run in a
-checkout that has a `genesis/` at all.
+**Building them in CI** was tried and replaced by the fetch below. `make dist` needs
+only Go, so a machine keeping a checkout can produce the fourteen on every push — but
+they are unpinned, which is fine for testing and wrong for anything shipped, and it puts
+anchor's source on a machine that only wanted its output. Note the trap if you automate
+it anywhere else: anchor's `make release` depends on `genesis/genesis.pin`, and with no
+`genesis/` directory its rule **mints a new genesis root** instead of failing. Binaries
+pinned to a realm nobody else has ever seen enrol perfectly and then never handshake.
 
-**Fetching at build time** from `GET /anchor/release` is the obvious next step and is
-not wired up: that shelf currently serves 2 of the 14 it needs (linux/amd64 only). If
-it is widened to all seven platforms, or its per-binary `url` is pointed at object
-storage, a lockfile-driven fetcher replaces `make anchor-bins` and a fresh clone
-becomes self-sufficient. The manifest already carries what such a fetcher needs —
-`sha256` per binary, `ETag` as the digest, and the genesis `pin`.
+**Fetching at build time** is what `FETCH=1` does, and it is the answer the three above
+were circling. `GET /anchor/release` serves a manifest — `sha256` and a `url` per
+binary, plus the genesis `pin` — and what it names is the pinned release build. No
+credential: what the shelf serves is what conflux already ships, since `//go:embed` puts
+these exact bytes inside every published conflux, so a public shelf discloses nothing a
+release download does not.
+
+That is also why it can be public while anchor stays private. conflux needs anchor's
+*output*, and the output is not the secret.
 
 Note that `go install` cannot work under any of these, fetch included: the module zip
 the proxy serves will not contain the binaries. conflux is distributed as release

--- a/docs/build.md
+++ b/docs/build.md
@@ -70,6 +70,13 @@ What it refuses, and why each is worth a refusal:
 A rejected download is never renamed into place, so a failed fetch leaves what was there
 before rather than a half-written binary.
 
+A failed fetch under `FETCH=1` is fatal rather than falling back to placeholders: asking
+for the real binaries and silently getting two-line text files answers a different
+question, and it buries the useful error — the fetcher has just printed which binaries
+are missing, and a fallback puts "holds placeholders" underneath it as the last word.
+The placeholder path is still there for when nothing was asked for, which is what lets a
+machine with no anchor and no network run `gofmt` and the unit tests.
+
 **`FETCH=1` is opt-in for now.** The macOS and Windows CI jobs run `anchor-bins` too and
 need only the two files their own build tag names, so fetching all fourteen there would
 move 284 MB to compile 43. Once the shelf serves every target and per-target narrowing

--- a/docs/build.md
+++ b/docs/build.md
@@ -42,6 +42,12 @@ This is not a working conflux — it is what lets a machine with no access to th
 binaries still run `gofmt`, `go vet`, `staticcheck` and the unit tests, which is
 exactly what CI needs.
 
+CI is no longer in that state for the jobs that matter. `linux`, `service` and
+`integration` check anchor out beside conflux on the self-hosted runner and build
+`make dist`, so the eight tests that gate on `anchor.Supported` actually run; `cross`
+stays on placeholders deliberately, because what it asks is whether every target still
+compiles. See [testing.md](testing.md).
+
 A placeholder build is not able to masquerade as a real one:
 
 ```console
@@ -69,6 +75,15 @@ reached 840 MB from a single commit.
 `go install github.com/veil-net/conflux@latest` would embed 130 bytes of text and ship
 an `anchord` that is not one — failing at exec on a user's machine rather than at build
 time here.
+
+**Building it in CI** is what the runner does, and it is not a substitute for either.
+`make dist` needs only Go, so a machine that keeps a checkout can produce the fourteen
+on every push — but they are unpinned, which is fine for testing against a live realm
+and wrong for anything shipped. Note the trap if you automate this anywhere else:
+anchor's `make release` depends on `genesis/genesis.pin`, and with no `genesis/`
+directory its rule **mints a new genesis root** instead of failing. The resulting
+binaries enrol perfectly and never handshake. The CI action refuses to run in a
+checkout that has a `genesis/` at all.
 
 **Fetching at build time** from `GET /anchor/release` is the obvious next step and is
 not wired up: that shelf currently serves 2 of the 14 it needs (linux/amd64 only). If
@@ -136,6 +151,9 @@ stack trace a user sends back useless.
 | `make cross` | vet and build all seven, with the size gate |
 | `make dist` | build all seven into `dist/`, with `SHA256SUMS` |
 | `make golden` | rewrite the argv fixtures after an intended change |
+| `make image` | the systemd test image, from `dist/conflux-linux-amd64` |
+| `make service-test` | install and uninstall, in a container that boots systemd |
+| `make integration` | three nodes, one taint, over the real API (needs Docker) |
 | `make fmtcheck` `make vet` `make lint` `make tidycheck` | what CI checks |
 | `make all` | everything CI runs |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,9 +10,17 @@ conflux's: `up`, `proxy`, `start`, `down`, `install`, `uninstall`, `renew`, `sta
 service runs.
 
 anchorctl's, reached by typing them: `peers`, `route`, `routes`, `connect`, `punch`,
-`events`, `metrics`, `export`, `children`, `telemetry`, `send`, `subscribe`, `keygen`,
-`issue`, `delegate`, `renew-link`, `install-link`, `id`, `inspect`, `config`, `renew`,
-`mint-realm`, `mint-anchor`.
+`kill`, `events`, `metrics`, `export`, `children`, `telemetry`, `send`, `subscribe`,
+`keygen`, `issue`, `delegate`, `renew-link`, `install-link`, `id`, `inspect`, `config`,
+`root`, `mint-realm`, `mint-anchor`. The last three are absent from the binary conflux
+embeds: `root` mints a realm and is not in the lockdown build, and the two `mint-*`
+verbs exist only in it.
+
+`kill` is worth naming separately, because it is not what the word suggests and is not
+related to `down`. It makes another anchor **a realm-wide target** — `-target ANCHORID
+-days N` — needs a credential issued with `-admin`, travels by gossip, and nothing can
+end one early. Stopping the anchor on *this* machine is `conflux down`, which closes it
+gracefully and leaves the registration; see [service.md](service.md).
 
 ### The five collisions
 
@@ -55,7 +63,8 @@ refusal names `down` and `start` and the escape hatch.
 ```
 conflux up [--taint T]... [--ipv4 PREFIX | --no-ipv4] [--subnet CIDR]... [--interface NAME]
            [--uplink DEV | --no-uplink] [--peers HOST:PORT]... [--no-peers] [--api URL]
-           [--port N | --no-port] [--low-latency] [--serve-exit] [--use-exit]
+           [--port N | --no-port] [--low-latency] [--lan-discovery yes|no|auto]
+           [--serve-exit] [--use-exit]
 ```
 
 Enrols this machine if it has never been, starts an anchor in TUN mode, writes the
@@ -78,6 +87,7 @@ configuration, and registers the boot service.
 | `--no-port` | go back to letting the kernel pick. |
 | `--low-latency` | carry frames on QUIC datagrams: no head-of-line blocking between flows to one peer, and a lost frame stays lost rather than holding up the ones behind it. |
 | `--no-low-latency` | go back to carrying frames on streams. |
+| `--lan-discovery` | `yes`, `no`, or `auto`. Probe the networks this host is attached to for anchors of the same realm tree — a third bootstrap source, tried *with* the configured and remembered ones rather than as a fallback when they are empty. `auto` is the default and passes nothing, which leaves the answer to enrolment's own `lanDiscovery` and, failing that, to anchor, where it is on. Typing `auto` is the way back from a persisted `yes` or `no`. Refused as an explicit `yes` beside `--uplink`: there is no host network to probe and nothing on a cable to answer. It never replaces enrolment — the probe is sealed under the realm's root public key, which a machine only holds once it has enrolled. |
 | `--serve-exit` | offer this machine as a way out to the public internet. |
 | `--use-exit` | send this machine's own internet traffic over the overlay. |
 | `--no-serve-exit`, `--no-use-exit` | the way back from either. |
@@ -118,11 +128,11 @@ Needs root.
 ```
 conflux proxy PORT[/NETWORK]=BACKEND ... [--taint T]... [--uplink DEV | --no-uplink]
               [--peers HOST:PORT]... [--no-peers] [--api URL]
-              [--port N | --no-port] [--low-latency]
+              [--port N | --no-port] [--low-latency] [--lan-discovery yes|no|auto]
 ```
 
 Starts in userspace mode serving those backends. Same taint, uplink, peers, API,
-`--port` and `--low-latency` flags as `up`. Specs and flags may be written in either
+`--port`, `--low-latency` and `--lan-discovery` flags as `up`. Specs and flags may be written in either
 order.
 
 `--serve-exit` and `--use-exit` are not here: routing the public internet either way

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ Every directory is `0700` and every file `0600`.
   "peers": ["genesis.veilnet.com.au:4700"],
   "port": 4711,
   "lowLatency": false,
+  "lanDiscovery": false,
   "serveExit": false,
   "useExit": false,
   "tunName": "anchor0",
@@ -52,6 +53,7 @@ Every directory is `0700` and every file `0600`.
 | `peers` | bootstrap entries, `host:port` or `anchorxxx@host:port`. **Absent is the usual case and not a missing setting:** anchorctl takes the list from the enrolment manifest for exactly the fields no flag named, so an empty `peers` is what keeps the issuer's own nodes in play. Present, it overrides them. |
 | `port` | the UDP port to bind on every interface. Absent means the kernel picks one, which is the usual case. A port and not an address: an anchor listens everywhere, and the host's addresses change under it. Refused beside `uplink`, which binds no socket. |
 | `lowLatency` | carry layer-2 frames on QUIC datagrams instead of streams. Absent is false. Either mode. |
+| `lanDiscovery` | probe the host's own networks for anchors of this realm tree. Either mode. The one field here where **absent is not false**: it is `auto`, and it passes no flag at all, which is what leaves enrolment's own `lanDiscovery` in play. `false` and absent are different documents and `--lan-discovery no` writes the first of them. |
 | `serveExit`, `useExit` | route the public internet out of and into the overlay. Absent is false, and both are `tun` only — switching a machine to `proxy` clears them. |
 | `apiBaseUrl` | absent means the default. |
 

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -77,6 +77,26 @@ and never both, though that is the medium and not the mode.
 conflux checks all of this locally, before it starts anything, so the error names the
 flag you typed rather than arriving from a child process as a gRPC status.
 
+## Finding the realm, in either mode
+
+Neither mode changes how an anchor finds its realm, and `--lan-discovery` is available
+on both because of it. Three sources are tried together: the bootstrap list enrolment
+supplied (or `--peers`), the addresses that have worked before, and a link-scoped probe
+of the networks this host is attached to. The third is the one that setting names.
+
+It is additive and cannot be anything else. The probe is sealed under the realm's root
+public key, which a machine holds only after it has enrolled — so discovery decides who
+is worth dialling, never who is let in, and a node with discovery off still finds the
+realm through the list it was given. Turning it off is a privacy choice, not a
+connectivity one: a probe tells every host on the link that an anchor is here and which
+tree it belongs to, and a laptop repeats that on every network it joins. Nothing in it
+identifies the anchor.
+
+With `--uplink` it is off regardless — there is no host network to probe and nothing on
+a cable to answer — and anchor decides that for itself, which is why only an explicit
+`--lan-discovery yes` is refused there. A machine configured once and later moved onto a
+link keeps starting.
+
 ## Switching
 
 Running one replaces the other, and conflux says so:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,14 +130,19 @@ checkout and no credential. See [build.md](build.md).
 
 | job | machine | what it adds |
 |---|---|---|
-| `linux` | veilnet-dev | the suite under `-race`, with real pinned binaries — eight tests that had only ever skipped |
-| `linux-fork` | GitHub Linux | the same gate on placeholders, for a pull request from a fork |
+| `linux` | GitHub Linux | the suite under `-race`, with real pinned binaries — eight tests that had only ever skipped |
 | `cross` | GitHub Linux | vet and compile all seven targets, on placeholders |
 | `platforms` | GitHub macOS, Windows | path handling, file modes, the DACL |
 | `windows-tun` | GitHub Windows | the wintun pin, fetched the way an operator would |
 | `service` | veilnet-dev | `make service-test` — install registers, uninstall leaves nothing |
 | `integration` | veilnet-dev | `make integration` — three nodes against the live API |
 | `docs` | GitHub Linux | two greps; it needs nothing the runner has |
+
+A release runs all of it first. `release.yml` calls this workflow and waits on it, which
+is new: a tag push runs none of `ci.yml`'s own triggers, so before that a release was
+gated on nothing but a check that the binaries it was about to embed were real. Whether
+the code around them still worked was a convention — the tag is cut from a commit that
+was green on main — and a convention is not a check.
 
 **The binaries CI uses are the pinned ones.** That is what the shelf serves, and it is
 the property a locally-built `make dist` cannot have: an anchor pinned to the genesis
@@ -158,12 +163,17 @@ a reason: `pull_request` runs the workflow from the *head* of the pull request, 
 without a guard a fork could propose a workflow that runs its own code on a machine that
 survives the job, beside a Docker socket and a token that reads a private repository.
 
-So every self-hosted job is conditioned on the pull request not coming from a fork, and
-a fork gets `linux-fork` instead — the same gate on placeholders, which is what `linux`
-was for everybody before there was a machine to run it on. The two conditions are exact
-complements, so precisely one of them runs. A fork's change is still formatted, vetted,
-linted, raced and checked against the argv fixtures; what it does not get is the eight
-binary-dependent tests and the two container suites.
+So the two jobs that need the machine — `service` and `integration` — are conditioned on
+the pull request not coming from a fork. Everything else is hosted, which is most of the
+suite: a fork's change is formatted, vetted, linted, raced, cross-compiled and checked
+against the argv fixtures, with the real pinned binaries, on both platform legs. What it
+does not get is the two container suites.
+
+`linux` is hosted for a reason worth stating, since it was not before: it wants a Go
+toolchain and the anchor binaries and nothing else, and the binaries now come from a
+public shelf rather than a checkout of a private repository. A second copy of that job
+existed to give forks a placeholder-based fallback; it is gone, and forks get the real
+thing instead.
 
 **One runner process, deliberately.** The four Linux jobs queue rather than run beside
 each other, so a push costs their sum. Do not register a second process to win that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,8 +130,8 @@ checkout and no credential. See [build.md](build.md).
 
 | job | machine | what it adds |
 |---|---|---|
-| `linux` | GitHub Linux | the suite under `-race`, with real pinned binaries — eight tests that had only ever skipped |
-| `cross` | GitHub Linux | vet and compile all seven targets, on placeholders |
+| `linux` | veilnet-dev | the suite under `-race`, with real pinned binaries — eight tests that had only ever skipped |
+| `cross` | veilnet-dev | vet and compile all seven targets, on placeholders |
 | `platforms` | GitHub macOS, Windows | path handling, file modes, the DACL |
 | `windows-tun` | GitHub Windows | the wintun pin, fetched the way an operator would |
 | `service` | veilnet-dev | `make service-test` — install registers, uninstall leaves nothing |
@@ -163,17 +163,18 @@ a reason: `pull_request` runs the workflow from the *head* of the pull request, 
 without a guard a fork could propose a workflow that runs its own code on a machine that
 survives the job, beside a Docker socket and a token that reads a private repository.
 
-So the two jobs that need the machine — `service` and `integration` — are conditioned on
-the pull request not coming from a fork. Everything else is hosted, which is most of the
-suite: a fork's change is formatted, vetted, linted, raced, cross-compiled and checked
-against the argv fixtures, with the real pinned binaries, on both platform legs. What it
-does not get is the two container suites.
+So the four Linux jobs handle a fork two different ways. `service` and `integration`
+refuse it: they want Docker and a privileged container on a machine that is not thrown
+away, and there is no substitute for that. `linux` and `cross` name their runner with an
+expression instead of a label, so a fork's pull request falls back to a GitHub image and
+still gets the gate.
 
-`linux` is hosted for a reason worth stating, since it was not before: it wants a Go
-toolchain and the anchor binaries and nothing else, and the binaries now come from a
-public shelf rather than a checkout of a private repository. A second copy of that job
-existed to give forks a placeholder-based fallback; it is gone, and forks get the real
-thing instead.
+The fallback costs a fork nothing, which is new. The anchor binaries come from a public
+shelf now rather than a checkout of a private repository, so a hosted runner fetches
+exactly what veilnet-dev does — the duplicate job that used to cover forks could not, and
+handed them placeholders. A fork's change is formatted, vetted, linted, raced,
+cross-compiled and checked against the argv fixtures with the real pinned binaries, on
+both platform legs. What it does not get is the two container suites.
 
 **One runner process, deliberately.** The four Linux jobs queue rather than run beside
 each other, so a push costs their sum. Do not register a second process to win that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,7 +130,8 @@ beside conflux and runs `make dist`, so the binaries are real on every push.
 | job | machine | what it adds |
 |---|---|---|
 | `linux` | veilnet-dev | the suite under `-race`, with real binaries — eight tests that had only ever skipped |
-| `cross` | veilnet-dev | vet and compile all seven targets, on placeholders |
+| `linux-fork` | GitHub Linux | the same gate on placeholders, for a pull request from a fork |
+| `cross` | GitHub Linux | vet and compile all seven targets, on placeholders |
 | `platforms` | GitHub macOS, Windows | path handling, file modes, the DACL |
 | `windows-tun` | GitHub Windows | the wintun pin, fetched the way an operator would |
 | `service` | veilnet-dev | `make service-test` — install registers, uninstall leaves nothing |
@@ -144,6 +145,20 @@ conflux built from that enrols against the live API perfectly and then never han
 with anything. So the composite action refuses to run anywhere near a `genesis/`
 directory, builds `dist`, and prints which of the two it used. `release.yml` is
 unchanged and still refuses anything but the real thing.
+
+**conflux is public and anchor is not**, which is the one thing that shaped this more
+than the runner itself. Using a self-hosted runner from a public repository is a
+separate organisation setting from repository access, and GitHub keeps it separate for
+a reason: `pull_request` runs the workflow from the *head* of the pull request, so
+without a guard a fork could propose a workflow that runs its own code on a machine that
+survives the job, beside a Docker socket and a token that reads a private repository.
+
+So every self-hosted job is conditioned on the pull request not coming from a fork, and
+a fork gets `linux-fork` instead — the same gate on placeholders, which is what `linux`
+was for everybody before there was a machine to run it on. The two conditions are exact
+complements, so precisely one of them runs. A fork's change is still formatted, vetted,
+linted, raced and checked against the argv fixtures; what it does not get is the eight
+binary-dependent tests and the two container suites.
 
 **One runner process, deliberately.** The four Linux jobs queue rather than run beside
 each other, so a push costs their sum. Do not register a second process to win that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -144,6 +144,13 @@ gated on nothing but a check that the binaries it was about to embed were real. 
 the code around them still worked was a convention — the tag is cut from a commit that
 was green on main — and a convention is not a check.
 
+It also fetches those binaries now, which is what made a release from CI possible at all.
+`anchor/bin` is not in git, so a release runner had no source for it and the workflow
+failed on its own error message saying so. Both release jobs fetch from the shelf, and
+neither pins anything: a release carries whatever anchor published most recently, which
+is the intent — conflux ships the newest anchor, not a remembered one. All seven targets
+are cross-built from the one Linux machine, `CGO_ENABLED=0` throughout.
+
 **The binaries CI uses are the pinned ones.** That is what the shelf serves, and it is
 the property a locally-built `make dist` cannot have: an anchor pinned to the genesis
 realm refuses to handshake with any other tree. So `integration` now exercises the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -122,14 +122,15 @@ never who is let in. Loopback is not probed, so two anchors on one machine still
 
 ## What CI runs, and on what
 
-Every Linux job is on **veilnet-dev**, a self-hosted runner, which is what makes the
-two container suites possible at all: `anchor/bin` is not in git, and a hosted runner
-that is destroyed after every job has no way to get it. veilnet-dev checks anchor out
-beside conflux and runs `make dist`, so the binaries are real on every push.
+Every Linux job that needs Docker is on **veilnet-dev**, a self-hosted runner. What
+makes the two container suites possible, though, is not the machine — it is that
+`anchor/bin` finally has a source CI can reach. `make anchor-bins FETCH=1` fetches the
+**pinned** release build from the shelf and verifies every digest, with no anchor
+checkout and no credential. See [build.md](build.md).
 
 | job | machine | what it adds |
 |---|---|---|
-| `linux` | veilnet-dev | the suite under `-race`, with real binaries — eight tests that had only ever skipped |
+| `linux` | veilnet-dev | the suite under `-race`, with real pinned binaries — eight tests that had only ever skipped |
 | `linux-fork` | GitHub Linux | the same gate on placeholders, for a pull request from a fork |
 | `cross` | GitHub Linux | vet and compile all seven targets, on placeholders |
 | `platforms` | GitHub macOS, Windows | path handling, file modes, the DACL |
@@ -138,13 +139,17 @@ beside conflux and runs `make dist`, so the binaries are real on every push.
 | `integration` | veilnet-dev | `make integration` — three nodes against the live API |
 | `docs` | GitHub Linux | two greps; it needs nothing the runner has |
 
-**The binaries CI builds are unpinned.** `make dist` in the anchor repo needs only Go;
-`make release` needs a genesis key that is not on any runner, and — the part worth
-knowing — if `genesis/` is absent its rule *mints a new root* rather than failing. A
-conflux built from that enrols against the live API perfectly and then never handshakes
-with anything. So the composite action refuses to run anywhere near a `genesis/`
-directory, builds `dist`, and prints which of the two it used. `release.yml` is
-unchanged and still refuses anything but the real thing.
+**The binaries CI uses are the pinned ones.** That is what the shelf serves, and it is
+the property a locally-built `make dist` cannot have: an anchor pinned to the genesis
+realm refuses to handshake with any other tree. So `integration` now exercises the
+binaries that actually ship, rather than a development cross-build that would join
+anything.
+
+It follows that CI tests against the **production realm** and nothing else, which is the
+right answer here and a thing to keep true. `genesis.veilnet.com.au:4700` carries the
+same pin, so the dev procedure below still works from a fetched build; a test node
+minted from its own root would not, and the failure would be the one the next section
+describes — enrols fine, never handshakes.
 
 **conflux is public and anchor is not**, which is the one thing that shaped this more
 than the runner itself. Using a self-hosted runner from a public repository is a
@@ -236,6 +241,11 @@ Two things worth checking deliberately, because neither is obvious from a passin
   build time (`-X anchor.pinnedGenesis`, see [build.md](build.md)). A test node minted
   from a different root will enrol fine and then never handshake, because the pin is
   what refuses it. That failure is on the anchor side, not conflux's.
+
+  This node carries **the same pin as production**, which is what makes it usable from
+  an ordinary fetched build at all. Worth checking rather than assuming after the node
+  is ever rebuilt: `make anchor-bins FETCH=1` prints the realm it fetched, and it has to
+  be the one the test node answers for.
 
 ## What has no coverage, and why
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,7 +136,7 @@ checkout and no credential. See [build.md](build.md).
 | `windows-tun` | GitHub Windows | the wintun pin, fetched the way an operator would |
 | `service` | veilnet-dev | `make service-test` — install registers, uninstall leaves nothing |
 | `integration` | veilnet-dev | `make integration` — three nodes against the live API |
-| `docs` | GitHub Linux | two greps; it needs nothing the runner has |
+| `docs` | veilnet-dev | two greps |
 
 A release runs all of it first. `release.yml` calls this workflow and waits on it, which
 is new: a tag push runs none of `ci.yml`'s own triggers, so before that a release was
@@ -163,18 +163,17 @@ a reason: `pull_request` runs the workflow from the *head* of the pull request, 
 without a guard a fork could propose a workflow that runs its own code on a machine that
 survives the job, beside a Docker socket and a token that reads a private repository.
 
-So the four Linux jobs handle a fork two different ways. `service` and `integration`
-refuse it: they want Docker and a privileged container on a machine that is not thrown
-away, and there is no substitute for that. `linux` and `cross` name their runner with an
-expression instead of a label, so a fork's pull request falls back to a GitHub image and
-still gets the gate.
+Every Linux job refuses a fork's pull request, and nothing stands in for them. Since the
+platform legs need the gate, a fork's pull request runs nothing at all.
 
-The fallback costs a fork nothing, which is new. The anchor binaries come from a public
-shelf now rather than a checkout of a private repository, so a hosted runner fetches
-exactly what veilnet-dev does — the duplicate job that used to cover forks could not, and
-handed them placeholders. A fork's change is formatted, vetted, linted, raced,
-cross-compiled and checked against the argv fixtures with the real pinned binaries, on
-both platform legs. What it does not get is the two container suites.
+That is the deliberate position rather than an oversight. A machine that survives the job
+does not run a stranger's code, and the alternative — a hosted copy of the gate, for
+forks only — was tried here and is worse than the gap. Two near-identical jobs with
+complementary conditions means one is always skipped, and the one that rots is the one
+nobody is watching.
+
+A fork's change is therefore reviewed rather than gated. If that becomes the wrong trade,
+the honest fix is a second machine, not a second copy of the gate.
 
 **One runner process, deliberately.** The four Linux jobs queue rather than run beside
 each other, so a push costs their sum. Do not register a second process to win that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,9 +36,14 @@ header and checks the machine field against `GOARCH`. It exists because a wrong 
 one — builds and links perfectly and fails at exec on somebody else's machine.
 
 It skips when `anchor/bin` holds the placeholders `make anchor-bins` writes with no
-anchor checkout available, which is the state CI is in. `anchor.Supported` is a size
-check for the same reason, so a placeholder build reports that it carries no anchor
-binaries rather than pretending.
+anchor checkout available. `anchor.Supported` is a size check for the same reason, so
+a placeholder build reports that it carries no anchor binaries rather than pretending.
+
+That used to be the state CI was in, and a skip is green — so this test and seven
+others had never run on any machine but a developer's. The `linux` job builds anchor
+beside conflux now, and asserts afterwards that none of the eight skipped: a job that
+provides the binaries and then reports "no anchor pair" has lost them, and saying so is
+the difference between a gate and a decoration.
 
 **The argv goldens**, in `internal/anchorctl/testdata/argv/`, hold one file per
 scenario, one argument per line. Argv construction is where a wrapper's bugs live and
@@ -69,9 +74,14 @@ and restarting it is the reboot.
 built `conflux` in beside it, then:
 
 ```console
-$ make anchor-bins && make dist
-$ cp dist/conflux-linux-amd64 test/systemd/conflux
-$ docker build -t conflux-systemd-test test/systemd
+$ make anchor-bins && make integration   # the whole suite, three nodes
+$ make service-test                      # or just the unit, which enrols nothing
+```
+
+By hand, which is what those run:
+
+```console
+$ make anchor-bins && make image
 $ docker run -d --name cfx-a --privileged --cgroupns=host \
     -v /sys/fs/cgroup:/sys/fs/cgroup:rw --device /dev/net/tun conflux-systemd-test
 $ docker exec cfx-a conflux up --taint mynet --ipv4 10.128.0.1/24
@@ -83,6 +93,75 @@ A second container joining with the same taint gives a real two-node reachabilit
 test. Allow up to a minute after the second node starts for gossip to find it — the
 observed range is 15 to 60 seconds — and `conflux peers` shows `DATA yes` on the peer
 once the taints have been compared.
+
+All of that is `make integration`, and the two assertions above on their own are
+`make service-test`. Both build the image first. They were a recipe here and a copy of
+the same three lines in `ci.yml` until the targets existed, which is two places for one
+sequence to drift; CI runs the same command a developer does.
+
+### Local network discovery, and the control for it
+
+Two containers on one Docker bridge are on the same link, which is the one thing no Go
+test in this tree can arrange: a real kernel, real multicast, a real answer. So
+`make integration` asserts `anchor_lan_peers_found_total` is **non-zero** on a node —
+non-zero and not merely present, because the series is created the first time it is
+written and a grep for the name alone passes on an anchor that never found anything.
+
+The third node is the control, and it is why the suite enrols three times. It joins
+with `--lan-discovery no` and names no `--peers` at all, and it must *still* reach the
+realm: the manifest's own bootstrap list is what carries it, which is what proves
+discovery is a third source rather than a load-bearing one. Its own counter staying at
+zero is what proves the flag reached anchor rather than being accepted by conflux and
+dropped.
+
+Note what discovery cannot do, and anchor's own `docs/discovery.md` is the reference:
+the probe is sealed under the realm's **root public key**, which a node only holds after
+it has enrolled. So it never replaces enrolment — it decides who is worth dialling,
+never who is let in. Loopback is not probed, so two anchors on one machine still need
+`--peers`.
+
+## What CI runs, and on what
+
+Every Linux job is on **veilnet-dev**, a self-hosted runner, which is what makes the
+two container suites possible at all: `anchor/bin` is not in git, and a hosted runner
+that is destroyed after every job has no way to get it. veilnet-dev checks anchor out
+beside conflux and runs `make dist`, so the binaries are real on every push.
+
+| job | machine | what it adds |
+|---|---|---|
+| `linux` | veilnet-dev | the suite under `-race`, with real binaries — eight tests that had only ever skipped |
+| `cross` | veilnet-dev | vet and compile all seven targets, on placeholders |
+| `platforms` | GitHub macOS, Windows | path handling, file modes, the DACL |
+| `windows-tun` | GitHub Windows | the wintun pin, fetched the way an operator would |
+| `service` | veilnet-dev | `make service-test` — install registers, uninstall leaves nothing |
+| `integration` | veilnet-dev | `make integration` — three nodes against the live API |
+| `docs` | GitHub Linux | two greps; it needs nothing the runner has |
+
+**The binaries CI builds are unpinned.** `make dist` in the anchor repo needs only Go;
+`make release` needs a genesis key that is not on any runner, and — the part worth
+knowing — if `genesis/` is absent its rule *mints a new root* rather than failing. A
+conflux built from that enrols against the live API perfectly and then never handshakes
+with anything. So the composite action refuses to run anywhere near a `genesis/`
+directory, builds `dist`, and prints which of the two it used. `release.yml` is
+unchanged and still refuses anything but the real thing.
+
+**One runner process, deliberately.** The four Linux jobs queue rather than run beside
+each other, so a push costs their sum. Do not register a second process to win that
+back — anchor's `docs/ci.md` records the measurement that argues against it. More
+parallelism wants a second machine.
+
+**A machine that is not thrown away.** Both container suites reap their fixed container
+names before themselves as well as after, because a cancelled run fires neither an
+`EXIT` trap nor an `if: always()` step, and the leftover name fails the *next* run for a
+reason that has nothing to do with the commit under test. `test/preflight.sh` says what
+the machine gives them — Docker, `/dev/net/tun`, cgroup v2, IPv6 — before anything is
+built, because each of those otherwise fails much later and names something else.
+
+One consequence of leaving hosted VMs: their runner user is unprivileged and a
+self-hosted one may not be. `TestWriteFileAtomicPreservesOnFailure` makes a directory
+read-only and expects the write to fail, which is not true for root — it now probes
+whether the chmod took and says so rather than failing. Nothing else in the suite
+depends on not being root.
 
 ## The genesis test node
 
@@ -156,10 +235,13 @@ Two things worth checking deliberately, because neither is obvious from a passin
   synthetic inputs. Nothing in this tree opens a device or a pseudo-terminal: the link
   itself is anchor's to test, and it does, over a real pty. Two machines on a cable
   have no runner, so the watcher's *reopen* path is reasoned about rather than run.
-- **The boot service and the two-node integration test, in CI.** Both need the real
-  anchor binaries, which are not in git and which a runner has no way to fetch, so
-  both are `workflow_dispatch` only. They are run locally: `./test/integration.sh`.
-  When `anchor/bin` gains a source CI can reach, remove the `if:` on those two jobs.
+- **A conflux built from pinned binaries, in CI.** This is the one that replaced
+  "the boot service and the integration test, in CI", which are now run on every push
+  — see [the CI section](#what-ci-runs-and-on-what) below. What CI cannot do is build
+  what ships: `make release` needs a genesis key that never leaves the maintainer's
+  machine, so CI builds `make dist` and the realm-pin path is exercised by hand.
+  A green `integration` says conflux drives anchor correctly; it does not say the
+  shipped artifact carries the right pin.
 
 A local fake for the enrolment API is used for the client's error paths, but it cannot
 stand in for a full end-to-end test: the shipped `anchord` is pinned to the production

--- a/internal/anchorctl/args.go
+++ b/internal/anchorctl/args.go
@@ -50,6 +50,13 @@ type StartMode struct {
 	// the same instruction, and omitting keeps the argv shorter.
 	LowLatency bool
 
+	// LANDiscovery probes the host's own networks for anchors of this realm tree.
+	// Nil passes no flag, which is what leaves the manifest's lanDiscovery in play --
+	// the rule Peers and Port follow, and unlike LowLatency, which no manifest field
+	// describes. Non-nil is passed in whichever direction, because an explicit flag
+	// is the only thing that beats a document here.
+	LANDiscovery *bool
+
 	// ServeExit and UseExit route the public internet out of and into the overlay.
 	// Always passed, in both directions: the manifest does carry these two, and an
 	// anchor that became an exit because a document said so is a surprise conflux
@@ -70,10 +77,11 @@ func ModeFromConfig(c *config.Config, anchorDir string) StartMode {
 		Uplink:  c.Uplink,
 		Peers:   c.Peers,
 
-		Port:       c.Port,
-		LowLatency: c.LowLatency,
-		ServeExit:  c.ServeExit,
-		UseExit:    c.UseExit,
+		Port:         c.Port,
+		LowLatency:   c.LowLatency,
+		LANDiscovery: c.LANDiscovery,
+		ServeExit:    c.ServeExit,
+		UseExit:      c.UseExit,
 	}
 
 	if m.TUN {
@@ -134,6 +142,14 @@ func (m StartMode) Args() []string {
 	// default applies to an omitted flag and an explicit false says the same thing.
 	if m.LowLatency {
 		args = append(args, "-low-latency=true")
+	}
+
+	// Only when the operator said so, and then in whichever direction. Unlike
+	// -low-latency above, the manifest does carry lanDiscovery, so an omitted flag
+	// is the issuer's answer rather than anchorctl's default -- and an explicit
+	// false has to be passed to mean anything at all.
+	if m.LANDiscovery != nil {
+		args = append(args, "-lan-discovery="+yesNo(*m.LANDiscovery))
 	}
 
 	args = append(args, "-tun="+boolText(m.TUN))
@@ -231,4 +247,18 @@ func boolText(v bool) string {
 	}
 
 	return "false"
+}
+
+// yesNo renders a tristate's two decided values the way anchorctl spells them.
+//
+// Not boolText: -lan-discovery is a string flag over yes/no/auto, not a bool, so
+// "true" would be accepted today only because anchorctl's parser happens to take it
+// as a synonym. The canonical spelling is the one its own help text uses, and a
+// golden file that reads -lan-discovery=no says what it does without a lookup.
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+
+	return "no"
 }

--- a/internal/anchorctl/args_test.go
+++ b/internal/anchorctl/args_test.go
@@ -88,6 +88,24 @@ var scenarios = map[string]StartMode{
 		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
 		LowLatency: true, Dir: "/var/lib/conflux/anchor",
 	},
+	// The three lan-discovery answers. "auto" is the absence of a golden of its own:
+	// up-minimal above is it, and the assertion that matters is that no
+	// -lan-discovery appears there -- an auto that emitted a flag would override the
+	// manifest with anchorctl's default on every machine that never asked.
+	"up-lan-discovery-yes": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		LANDiscovery: boolp(true), Dir: "/var/lib/conflux/anchor",
+	},
+	"up-lan-discovery-no": {
+		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
+		LANDiscovery: boolp(false), Dir: "/var/lib/conflux/anchor",
+	},
+	"proxy-lan-discovery-no": {
+		Taints:       []string{"brhk-2mq9-tzva-6pjs"},
+		Proxies:      []string{"8080=127.0.0.1:3000"},
+		LANDiscovery: boolp(false),
+		Dir:          "/var/lib/conflux/anchor",
+	},
 	"up-exit": {
 		TUN: true, TUNName: "anchor0", Taints: []string{"brhk-2mq9-tzva-6pjs"},
 		ServeExit: true, UseExit: true, Dir: "/var/lib/conflux/anchor",
@@ -196,6 +214,29 @@ func TestValidateMirrorsAnchorsRule(t *testing.T) {
 	for why, m := range ok {
 		if err := m.Validate(); err != nil {
 			t.Errorf("Validate refused %s: %v", why, err)
+		}
+	}
+}
+
+func boolp(v bool) *bool { return &v }
+
+// TestAutoEmitsNoLANDiscoveryFlag is the assertion the goldens cannot make.
+//
+// A golden says what an argv contains; this says what it must not. Nil means auto
+// means "the manifest decides", and the only way that holds is if no flag is written
+// at all -- anchorctl takes a manifest field only for a flag nobody typed. An auto
+// that emitted -lan-discovery=yes would look identical in every test here and would
+// quietly override the issuer on every machine that never asked.
+func TestAutoEmitsNoLANDiscoveryFlag(t *testing.T) {
+	for name, mode := range scenarios {
+		if mode.LANDiscovery != nil {
+			continue
+		}
+
+		for _, a := range mode.Args() {
+			if strings.HasPrefix(a, "-lan-discovery") {
+				t.Errorf("%s: LANDiscovery is nil but the argv carries %q", name, a)
+			}
 		}
 	}
 }

--- a/internal/anchorctl/testdata/argv/proxy-lan-discovery-no.golden
+++ b/internal/anchorctl/testdata/argv/proxy-lan-discovery-no.golden
@@ -1,0 +1,13 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-lan-discovery=no
+-tun=false
+-serve-exit=false
+-use-exit=false
+-serve-proxy
+8080=127.0.0.1:3000

--- a/internal/anchorctl/testdata/argv/up-lan-discovery-no.golden
+++ b/internal/anchorctl/testdata/argv/up-lan-discovery-no.golden
@@ -1,0 +1,13 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-lan-discovery=no
+-tun=true
+-tun-name
+anchor0
+-serve-exit=false
+-use-exit=false

--- a/internal/anchorctl/testdata/argv/up-lan-discovery-yes.golden
+++ b/internal/anchorctl/testdata/argv/up-lan-discovery-yes.golden
@@ -1,0 +1,13 @@
+start
+-manifest
+-
+-dir
+/var/lib/conflux/anchor
+-taints
+brhk-2mq9-tzva-6pjs
+-lan-discovery=yes
+-tun=true
+-tun-name
+anchor0
+-serve-exit=false
+-use-exit=false

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -411,3 +411,75 @@ func TestPeersAreValidatedBeforeTheyReachAnchor(t *testing.T) {
 		t.Errorf("peers %v were refused: %v", good, err)
 	}
 }
+
+// TestProxyKeepsItsOwnLANDiscoveryFlag: the tristate is a value flag, and proxy's
+// positional parser is the one place that has to be told so. `--lan-discovery no
+// 8080=...` reads as two positionals to a parser that thinks the flag is a boolean,
+// and the second of them is a proxy spec called "no".
+func TestProxyKeepsItsOwnLANDiscoveryFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"--lan-discovery", "no", "8080=127.0.0.1:3000"},
+		{"8080=127.0.0.1:3000", "--lan-discovery=yes"},
+		{"--lan-discovery", "auto", "8080=127.0.0.1:3000"},
+	} {
+		if hint := unknownProxyFlag(args); hint != "" {
+			t.Errorf("%v: unknownProxyFlag said %q", args, hint)
+		}
+
+		specs, _ := splitPositional(args)
+
+		if len(specs) != 1 || specs[0] != "8080=127.0.0.1:3000" {
+			t.Errorf("%v: positional args are %v, want just the port spec", args, specs)
+		}
+	}
+}
+
+// TestLANDiscoveryTristate covers the three answers and the two rules that are not
+// obvious from them: an absent flag keeps what is configured, because that is how
+// every other re-run of up keeps its settings, and typing auto is the way back from
+// a persisted yes or no -- the job the --no-x negations do for the toggles.
+func TestLANDiscoveryTristate(t *testing.T) {
+	yes, no := true, false
+
+	for _, tc := range []struct {
+		name    string
+		typed   bool
+		value   string
+		current *bool
+		want    *bool
+	}{
+		{"absent keeps a persisted yes", false, "auto", &yes, &yes},
+		{"absent keeps a persisted no", false, "auto", &no, &no},
+		{"absent keeps auto", false, "auto", nil, nil},
+		{"yes sets yes", true, "yes", nil, &yes},
+		{"no sets no", true, "no", &yes, &no},
+		{"auto is the way back", true, "auto", &yes, nil},
+		{"case and space are forgiven", true, " YES ", nil, &yes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			typed := map[string]bool{}
+			if tc.typed {
+				typed["lan-discovery"] = true
+			}
+
+			got, err := chooseTristate("lan-discovery", typed, tc.value, tc.current)
+			if err != nil {
+				t.Fatalf("chooseTristate: %v", err)
+			}
+
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("got %v, want auto", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("got auto, want %v", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("got %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+
+	if _, err := chooseTristate("lan-discovery",
+		map[string]bool{"lan-discovery": true}, "maybe", nil); err == nil {
+		t.Error("a value that is not yes, no or auto should be refused")
+	}
+}

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -58,6 +58,8 @@ func runProxy(ctx context.Context, args []string) int {
 	noPeers := fs.Bool("no-peers", false, "forget the bootstrap list and go back to the one enrolment supplies")
 	apiBase := fs.String("api", "", "enrolment API base URL")
 	port := fs.Uint("port", 0, "UDP port to bind on every interface; omit to let the kernel pick one")
+	lanDisco := fs.String("lan-discovery", "auto",
+		"find peers on the networks this host is attached to: yes, no, or auto to let enrolment decide")
 
 	// Read through typedFlags rather than by value; see the same block in up.go. The
 	// two exit flags are absent on purpose: both need a host interface, which
@@ -133,7 +135,7 @@ func runProxy(ctx context.Context, args []string) int {
 	}
 
 	// Before the warning below; see the same move in up.go.
-	if err := chooseTuning(cfg, typedFlags(fs), *port, false); err != nil {
+	if err := chooseTuning(cfg, typedFlags(fs), *port, *lanDisco, false); err != nil {
 		return fail(err)
 	}
 
@@ -190,6 +192,7 @@ func unknownProxyFlag(args []string) string {
 		"-no-port": true, "--no-port": true,
 		"-low-latency": true, "--low-latency": true,
 		"-no-low-latency": true, "--no-low-latency": true,
+		"-lan-discovery": true, "--lan-discovery": true,
 		"-h": true, "--help": true, "-help": true,
 	}
 
@@ -240,9 +243,13 @@ func splitPositional(args []string) (positional, flags []string) {
 // takesValue reports whether a flag written as `-flag value` swallows the argument
 // after it. Only conflux proxy's own value-taking flags are here; --no-taint,
 // --no-uplink and --low-latency are booleans and take nothing.
+//
+// --lan-discovery is here rather than with the booleans because it is a tristate
+// written as a value: missing it would read `conflux proxy --lan-discovery no
+// 8080=127.0.0.1:3000` as a proxy spec called "no".
 func takesValue(arg string) bool {
 	switch strings.TrimLeft(arg, "-") {
-	case "taint", "api", "uplink", "peers", "port":
+	case "taint", "api", "uplink", "peers", "port", "lan-discovery":
 		return true
 	default:
 		return false

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -39,7 +39,9 @@ func runUp(ctx context.Context, args []string) int {
 		noPeers  = fs.Bool("no-peers", false, "forget the bootstrap list and go back to the one enrolment supplies")
 		apiBase  = fs.String("api", "", "enrolment API base URL")
 		port     = fs.Uint("port", 0, "UDP port to bind on every interface; omit to let the kernel pick one")
-		peers    repeated
+		lanDisco = fs.String("lan-discovery", "auto",
+			"find peers on the networks this host is attached to: yes, no, or auto to let enrolment decide")
+		peers repeated
 	)
 
 	// Registered for the flag package and read through typedFlags, not through these
@@ -90,7 +92,7 @@ func runUp(ctx context.Context, args []string) int {
 	// refused before this machine is told its proxies are being replaced. The
 	// announcement is not a lie -- nothing is saved until bring -- but reading
 	// "replaces that" and then an error is a worse way to learn you typo'd a port.
-	if err := chooseTuning(cfg, typedFlags(fs), *port, true); err != nil {
+	if err := chooseTuning(cfg, typedFlags(fs), *port, *lanDisco, true); err != nil {
 		return fail(err)
 	}
 
@@ -175,6 +177,37 @@ func chooseToggle(name string, typed map[string]bool, current bool) (bool, error
 	}
 }
 
+// chooseTristate resolves a yes/no/auto flag against what is already configured.
+//
+// Three answers rather than two, so this is a value flag and not a --x/--no-x pair:
+// auto is the one that passes nothing to anchorctl and so leaves the manifest's own
+// answer in play, and a boolean has nowhere to put it. Typing --lan-discovery auto
+// is the way back from a persisted yes or no, which is the job the negations do for
+// the toggles above.
+//
+// An absent flag keeps what is configured, because that is how every other re-run of
+// up keeps its settings.
+func chooseTristate(name string, typed map[string]bool, value string, current *bool) (*bool, error) {
+	if !typed[name] {
+		return current, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "auto":
+		return nil, nil
+	case "yes":
+		yes := true
+
+		return &yes, nil
+	case "no":
+		no := false
+
+		return &no, nil
+	default:
+		return nil, fmt.Errorf("--%s %s: want yes, no or auto", name, value)
+	}
+}
+
 // choosePort decides the UDP port, keeping a persisted one when no flag names one.
 func choosePort(cfg *config.Config, typed map[string]bool, value uint) error {
 	on, off := typed["port"], typed["no-port"]
@@ -204,7 +237,7 @@ func choosePort(cfg *config.Config, typed map[string]bool, value uint) error {
 // exits is false on proxy, where the two exit flags are not registered at all: both
 // need a host interface, so offering them on the verb that has none would be offering
 // a setting whose only outcome is a refusal.
-func chooseTuning(cfg *config.Config, typed map[string]bool, port uint, exits bool) error {
+func chooseTuning(cfg *config.Config, typed map[string]bool, port uint, lanDisco string, exits bool) error {
 	if err := choosePort(cfg, typed, port); err != nil {
 		return err
 	}
@@ -215,6 +248,13 @@ func chooseTuning(cfg *config.Config, typed map[string]bool, port uint, exits bo
 	}
 
 	cfg.LowLatency = lowLatency
+
+	lan, err := chooseTristate("lan-discovery", typed, lanDisco, cfg.LANDiscovery)
+	if err != nil {
+		return err
+	}
+
+	cfg.LANDiscovery = lan
 
 	if !exits {
 		return nil

--- a/internal/config/atomic_test.go
+++ b/internal/config/atomic_test.go
@@ -104,13 +104,7 @@ func TestWriteFileAtomicPreservesOnFailure(t *testing.T) {
 
 	// A directory that cannot be written to is the reachable way to fail between
 	// "the old file exists" and "the new one is in place".
-	if runtime.GOOS != "windows" {
-		if err := os.Chmod(dir, 0o500); err != nil {
-			t.Fatalf("chmod dir: %v", err)
-		}
-
-		t.Cleanup(func() { os.Chmod(dir, 0o700) })
-
+	if runtime.GOOS != "windows" && unwritable(t, dir) {
 		if err := WriteFileAtomic(path, []byte("bad"), 0o600); err == nil {
 			t.Fatal("WriteFileAtomic succeeded into a read-only directory")
 		}
@@ -124,4 +118,36 @@ func TestWriteFileAtomicPreservesOnFailure(t *testing.T) {
 	if string(b) != "good" {
 		t.Errorf("content = %q after a failed write, want the previous %q", b, "good")
 	}
+}
+
+// unwritable makes dir read-only and reports whether that actually took.
+//
+// The premise, checked rather than assumed. chmod succeeds for root and root writes
+// anyway, so as root this half of the test was asserting nothing -- and it did not
+// skip, it failed, which is a worse way to assert nothing. That cost nothing while CI
+// was hosted VMs whose runner user is unprivileged; it is a red build the moment the
+// suite runs somewhere the runner process is root, which is what a self-hosted machine
+// may well be.
+//
+// The rest of the test is unaffected and still runs: whatever happened to the write,
+// the previous content must still be there afterwards.
+func unwritable(t *testing.T, dir string) bool {
+	t.Helper()
+
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Skipf("cannot make the directory read-only here: %v", err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	probe := filepath.Join(dir, ".writable-probe")
+	if err := os.WriteFile(probe, nil, 0o600); err == nil {
+		_ = os.Remove(probe)
+		t.Log("this directory is still writable after chmod 0500 -- running as root, " +
+			"so there is no unwritable case here to exercise")
+
+		return false
+	}
+
+	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,27 @@ type Config struct {
 	// it is off unless asked for.
 	LowLatency bool `json:"lowLatency,omitempty"`
 
+	// LANDiscovery probes the networks this host is attached to for anchors of the
+	// same realm tree -- a third bootstrap source, tried with the configured and
+	// remembered ones rather than as a fallback for when they are empty.
+	//
+	// A pointer because there are three answers and not two. Nil is "auto", which
+	// passes no flag and so leaves the manifest's own lanDiscovery in play, the same
+	// rule Port and Peers follow; anchor's default under that is on. True and false
+	// are the operator saying so, and an explicit flag beats the manifest.
+	//
+	// Worth the operator's hand rather than the issuer's alone: a probe tells every
+	// host on the link that an anchor is here and which tree it belongs to, and a
+	// laptop repeats that on every network it attaches to. Nothing identifies the
+	// anchor in it, but the disclosure is real and is not the issuer's to make
+	// quietly -- the argument the two exit settings above make for themselves.
+	//
+	// Refused as an explicit yes beside an Uplink, where there is no host network to
+	// probe. Nil and false are accepted there: anchor turns it off for an uplink
+	// regardless, and refusing a default nobody chose would fail every uplink anchor
+	// for a setting its operator never made.
+	LANDiscovery *bool `json:"lanDiscovery,omitempty"`
+
 	// ServeExit offers this anchor as a way out to the public internet, and
 	// UseExit sends this machine's own internet traffic over the overlay. Both
 	// need a host interface, so both are TUN only.
@@ -222,6 +243,17 @@ func (c *Config) Validate() error {
 			return fmt.Errorf(
 				"a port and an uplink are set together: an uplink carries layer 1 over %s and binds no socket, "+
 					"so there is no port to choose",
+				c.Uplink)
+		}
+
+		// Only an explicit yes, which is anchor's own rule and its reason: a machine
+		// configured once and later moved onto a cable would otherwise stop starting
+		// for a default nobody chose. --lan-discovery no and the unset auto are both
+		// accepted here, and anchor turns the probe off beside an uplink either way.
+		if c.LANDiscovery != nil && *c.LANDiscovery {
+			return fmt.Errorf(
+				"--lan-discovery yes and an uplink are set together: an uplink carries layer 1 over %s, "+
+					"so there is no host network to probe and nothing on a cable to answer",
 				c.Uplink)
 		}
 	}

--- a/internal/config/tuning_test.go
+++ b/internal/config/tuning_test.go
@@ -92,6 +92,83 @@ func TestPortAndUplinkAreRefusedTogether(t *testing.T) {
 	}
 }
 
+func TestLANDiscoveryYesAndUplinkAreRefusedTogether(t *testing.T) {
+	yes, no := true, false
+
+	c := base(ModeTUN)
+	c.Uplink = "/dev/ttyUSB0"
+	c.LANDiscovery = &yes
+
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("--lan-discovery yes beside an uplink should be refused: there is no host network to probe")
+	}
+
+	if !strings.Contains(err.Error(), "no host network to probe") {
+		t.Errorf("the error should say why; it said: %v", err)
+	}
+
+	// The two that are not an explicit ask are accepted, and this is the half worth
+	// asserting: anchor turns the probe off beside an uplink regardless, so refusing
+	// them would fail every machine that was configured once and later moved onto a
+	// cable -- for a setting its operator never made.
+	c.LANDiscovery = &no
+	if err := c.Validate(); err != nil {
+		t.Errorf("--lan-discovery no beside an uplink should validate: %v", err)
+	}
+
+	c.LANDiscovery = nil
+	if err := c.Validate(); err != nil {
+		t.Errorf("an unset lan-discovery beside an uplink should validate: %v", err)
+	}
+
+	// And yes is fine without the uplink.
+	c.Uplink, c.LANDiscovery = "", &yes
+	if err := c.Validate(); err != nil {
+		t.Errorf("--lan-discovery yes alone should validate: %v", err)
+	}
+}
+
+// TestLANDiscoveryRoundTripsAllThree: a *bool, so the document must tell "off" from
+// "not set". omitempty drops a nil and keeps a pointer to false, which is the whole
+// reason the field is a pointer -- a plain bool would read a persisted no back as an
+// auto on the next start and hand the answer to the manifest.
+func TestLANDiscoveryRoundTripsAllThree(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  *bool
+	}{
+		{"auto", nil},
+		{"yes", func() *bool { v := true; return &v }()},
+		{"no", func() *bool { v := false; return &v }()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := dirsForTest(t)
+
+			want := base(ModeTUN)
+			want.LANDiscovery = tc.set
+
+			if err := Save(d, want); err != nil {
+				t.Fatalf("Save: %v", err)
+			}
+
+			got, err := Load(d)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+
+			switch {
+			case tc.set == nil && got.LANDiscovery != nil:
+				t.Errorf("auto came back as %v; it must stay absent", *got.LANDiscovery)
+			case tc.set != nil && got.LANDiscovery == nil:
+				t.Errorf("%v came back as auto; the setting was dropped", *tc.set)
+			case tc.set != nil && *got.LANDiscovery != *tc.set:
+				t.Errorf("lanDiscovery is %v, want %v", *got.LANDiscovery, *tc.set)
+			}
+		})
+	}
+}
+
 // TestTuningSurvivesTheRoundTrip: the four new fields are omitempty, so a zero value
 // is absent from the document. What must not happen is a set one being dropped.
 func TestTuningSurvivesTheRoundTrip(t *testing.T) {

--- a/internal/shelf/shelf.go
+++ b/internal/shelf/shelf.go
@@ -1,0 +1,305 @@
+// Package shelf fetches the anchor binaries from the published release manifest.
+//
+// The binaries are not in git -- fourteen release builds are about 284 MB -- and until
+// now the only way to get them was a local anchor checkout, which is why CI ran on
+// placeholders and eight tests skipped on every machine but a developer's.
+//
+// The shelf is the answer that needs no credential. What it serves is what conflux
+// already ships: `//go:embed` puts these bytes inside every published conflux, so a
+// public shelf discloses nothing a release download does not. That is the whole reason
+// this can be an unauthenticated GET rather than a token for a private repository --
+// conflux needs anchor's *output*, and its output is not the secret. anchor's source
+// stays where it is.
+//
+// What is fetched is the *pinned* build. An anchor pinned to the genesis realm refuses
+// to handshake with any other tree, which is the property worth having and the one a
+// local `make dist` cannot give.
+package shelf
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultURL is where the manifest lives. Overridable so a dev shelf can be
+	// pointed at, and deliberately not a value any *runtime* path reads: this is a
+	// build-time source for bytes, not a thing a running conflux ever contacts.
+	DefaultURL = "https://api.veilnet.com.au/anchor/release"
+
+	// insecureEnv permits a plain-http shelf, for a test server. Named to match
+	// internal/enrol's own override rather than inventing a second spelling.
+	insecureEnv = "CONFLUX_ALLOW_INSECURE_API"
+
+	// formatVersion is the manifest shape this understands. A future version may
+	// mean anything, so an unknown one is refused rather than guessed at -- the same
+	// rule internal/enrol applies to a manifest it does not recognise.
+	formatVersion = 1
+
+	// maxManifest bounds the JSON; maxBinary bounds one download. An anchord is
+	// about 30 MB and anchorctl about 14, so 200 MB is far above anything real and
+	// far below anything that could fill a disk before the write fails.
+	maxManifest = 1 << 20
+	maxBinary   = 200 << 20
+
+	manifestTimeout = 30 * time.Second
+	binaryTimeout   = 10 * time.Minute
+)
+
+// Binary is one entry in the manifest.
+type Binary struct {
+	Name    string `json:"name"`
+	Program string `json:"program"`
+	OS      string `json:"os"`
+	Arch    string `json:"arch"`
+	Bytes   int64  `json:"bytes"`
+	SHA256  string `json:"sha256"`
+	URL     string `json:"url"`
+}
+
+// Manifest is what the shelf serves.
+type Manifest struct {
+	FormatVersion int      `json:"formatVersion"`
+	Pin           string   `json:"pin"`
+	Binaries      []Binary `json:"binaries"`
+}
+
+// Fetch downloads every binary named by want into dir, verifying each against the
+// digest the manifest gives for it.
+//
+// want is the set of file names conflux embeds -- "anchord-linux-amd64" and the other
+// thirteen. It is passed in rather than derived here so that the list of targets stays
+// in one place, scripts/anchor-bins.sh, which is also what prunes the directory.
+func Fetch(ctx context.Context, base string, want []string, dir string, log func(string, ...any)) error {
+	if err := checkScheme(base); err != nil {
+		return err
+	}
+
+	m, err := manifest(ctx, base)
+	if err != nil {
+		return err
+	}
+
+	if m.FormatVersion != formatVersion {
+		return fmt.Errorf("the shelf speaks manifest format %d and this conflux understands %d",
+			m.FormatVersion, formatVersion)
+	}
+
+	if m.Pin == "" {
+		return errors.New("the manifest carries no genesis pin, so nothing says which realm these are for")
+	}
+
+	byName := map[string]Binary{}
+
+	for _, b := range m.Binaries {
+		// anchoradmin can mint realm roots. It has no business on a public shelf and
+		// certainly none in anchor/bin, every file of which is a candidate for being
+		// embedded into every conflux a user runs. Refused here rather than deleted
+		// after the fact: if it is being served, that is worth stopping over.
+		if b.Program == "anchoradmin" || strings.HasPrefix(b.Name, "anchoradmin") {
+			return fmt.Errorf("the shelf is serving %q, which mints realm roots and must never be published", b.Name)
+		}
+
+		byName[b.Name] = b
+	}
+
+	log("shelf:   %s", base)
+	log("realm:   %s", m.Pin)
+
+	var missing []string
+
+	for _, name := range want {
+		if _, ok := byName[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+
+		return fmt.Errorf("the shelf serves %d of the %d binaries conflux embeds; missing:\n  %s",
+			len(want)-len(missing), len(want), strings.Join(missing, "\n  "))
+	}
+
+	for _, name := range want {
+		b := byName[name]
+
+		if err := download(ctx, base, b, filepath.Join(dir, name)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+
+		log("  ok   %-28s %5.1f MB  %s", name, float64(b.Bytes)/(1<<20), b.SHA256[:12])
+	}
+
+	return nil
+}
+
+func manifest(ctx context.Context, base string) (*Manifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, manifestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client(base).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching the manifest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the shelf answered %s", resp.Status)
+	}
+
+	var m Manifest
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxManifest)).Decode(&m); err != nil {
+		return nil, fmt.Errorf("the manifest is not the JSON this expects: %w", err)
+	}
+
+	return &m, nil
+}
+
+// download writes one binary, verifying its digest before it is put in place.
+//
+// Into a temporary file next to the target and renamed, so an interrupted fetch cannot
+// leave a half-written file that is a real binary of nearly the right size -- which is
+// exactly the shape neither the size gate in `make dist` nor the header check in
+// anchor.TestPairIsRealExecutables would catch.
+func download(ctx context.Context, base string, b Binary, dest string) error {
+	if err := sameHost(base, b.URL); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, binaryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, b.URL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client(base).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the shelf answered %s", resp.Status)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".anchor-fetch-*")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	sum := sha256.New()
+
+	n, err := io.Copy(io.MultiWriter(tmp, sum), io.LimitReader(resp.Body, maxBinary))
+	if err != nil {
+		return err
+	}
+
+	if b.Bytes != 0 && n != b.Bytes {
+		return fmt.Errorf("got %d bytes, the manifest says %d", n, b.Bytes)
+	}
+
+	if got := hex.EncodeToString(sum.Sum(nil)); !strings.EqualFold(got, b.SHA256) {
+		return fmt.Errorf("sha256 is %s, the manifest says %s", got, b.SHA256)
+	}
+
+	if err := tmp.Chmod(0o755); err != nil {
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), dest)
+}
+
+func client(base string) *http.Client {
+	u, _ := url.Parse(base)
+
+	return &http.Client{
+		// A download that follows a redirect to another host is one this did not
+		// agree to. The digest would still have to match, so this is belt and
+		// braces -- and cheap enough to keep, because the alternative is trusting
+		// that the digest check is never the only thing standing up.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if u != nil && req.URL.Host != u.Host {
+				return fmt.Errorf("refusing a redirect from %s to %s", u.Host, req.URL.Host)
+			}
+
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+
+			return nil
+		},
+	}
+}
+
+// sameHost refuses a per-binary url that points somewhere other than the manifest.
+//
+// The manifest names its own download URLs, so a compromised or mistaken shelf could
+// point them at a third party. The digest would catch substituted *content*; this
+// catches conflux being made to fetch from somewhere it was never told about, which is
+// worth refusing on its own.
+func sameHost(base, raw string) error {
+	b, err := url.Parse(base)
+	if err != nil {
+		return err
+	}
+
+	t, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%q is not a URL: %w", raw, err)
+	}
+
+	if t.Host != b.Host {
+		return fmt.Errorf("the manifest points at %s, which is not the shelf at %s", t.Host, b.Host)
+	}
+
+	return checkScheme(raw)
+}
+
+func checkScheme(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%q is not a URL: %w", raw, err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if os.Getenv(insecureEnv) == "1" {
+			return nil
+		}
+
+		return fmt.Errorf("%s is plain http (set %s=1 to override, for tests)", raw, insecureEnv)
+	default:
+		return fmt.Errorf("%s has scheme %q, want https", raw, u.Scheme)
+	}
+}

--- a/internal/shelf/shelf_test.go
+++ b/internal/shelf/shelf_test.go
@@ -1,0 +1,267 @@
+package shelf
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// serve stands up a shelf holding the given files, and returns its base URL.
+//
+// The manifest's own urls point back at this server, which is what makes the same-host
+// rule testable: a test that wants to break it rewrites them afterwards.
+func serve(t *testing.T, files map[string][]byte, edit func(*Manifest)) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	m := Manifest{FormatVersion: 1, Pin: "realmtestpin"}
+
+	for name, body := range files {
+		sum := sha256.Sum256(body)
+		m.Binaries = append(m.Binaries, Binary{
+			Name:   name,
+			Bytes:  int64(len(body)),
+			SHA256: hex.EncodeToString(sum[:]),
+			URL:    srv.URL + "/" + name,
+		})
+
+		mux.HandleFunc("/"+name, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(body)
+		})
+	}
+
+	if edit != nil {
+		edit(&m)
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(m)
+	})
+
+	// The test server is plain http, which Fetch refuses by design. Same override
+	// internal/enrol's client uses, and set through t.Setenv so it cannot leak.
+	t.Setenv(insecureEnv, "1")
+
+	return srv.URL
+}
+
+func quiet(string, ...any) {}
+
+func TestFetchWritesVerifiedBinaries(t *testing.T) {
+	files := map[string][]byte{
+		"anchord-linux-amd64":   []byte("an anchord, for the purposes of this test"),
+		"anchorctl-linux-amd64": []byte("an anchorctl"),
+	}
+
+	dir := t.TempDir()
+	base := serve(t, files, nil)
+
+	if err := Fetch(context.Background(), base, keys(files), dir, quiet); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+
+		if string(got) != string(want) {
+			t.Errorf("%s: content is %q, want %q", name, got, want)
+		}
+
+		// Executable, because the whole point is that libexec extracts and runs it.
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("%s: mode is %v, which is not executable", name, info.Mode().Perm())
+		}
+	}
+}
+
+// TestFetchRefusesAWrongDigest is the assertion the whole package exists for. A shelf
+// that serves the wrong bytes for a name is the failure no later gate catches: a real
+// binary of the right size passes the size gate in `make dist`, and one of the right
+// architecture passes anchor.TestPairIsRealExecutables.
+func TestFetchRefusesAWrongDigest(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("the right bytes")}
+
+	base := serve(t, files, func(m *Manifest) {
+		m.Binaries[0].SHA256 = strings.Repeat("00", sha256.Size)
+		m.Binaries[0].Bytes = 0 // so the length check does not fire first
+	})
+
+	dir := t.TempDir()
+
+	err := Fetch(context.Background(), base, keys(files), dir, quiet)
+	if err == nil {
+		t.Fatal("a digest that does not match should be refused")
+	}
+
+	if !strings.Contains(err.Error(), "sha256") {
+		t.Errorf("the error should name the digest; it said: %v", err)
+	}
+
+	// And nothing is left behind: a rejected download must not be renamed into place,
+	// or the next build embeds it.
+	if entries, _ := os.ReadDir(dir); len(entries) != 0 {
+		t.Errorf("a refused download left %d files in place", len(entries))
+	}
+}
+
+// TestFetchRefusesAnchoradmin: it mints realm roots, and anything in anchor/bin is a
+// candidate for being embedded into every conflux a user runs. Refused rather than
+// filtered, because a shelf serving it at all is worth stopping over.
+func TestFetchRefusesAnchoradmin(t *testing.T) {
+	files := map[string][]byte{
+		"anchord-linux-amd64":     []byte("fine"),
+		"anchoradmin-linux-amd64": []byte("not fine"),
+	}
+
+	base := serve(t, files, nil)
+
+	err := Fetch(context.Background(), base, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a shelf serving anchoradmin should be refused")
+	}
+
+	if !strings.Contains(err.Error(), "anchoradmin") {
+		t.Errorf("the error should name it; it said: %v", err)
+	}
+}
+
+func TestFetchNamesWhatIsMissing(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("only one of them")}
+
+	base := serve(t, files, nil)
+
+	err := Fetch(context.Background(), base,
+		[]string{"anchord-linux-amd64", "anchorctl-linux-amd64", "anchord-darwin-arm64"},
+		t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a partial shelf should be refused")
+	}
+
+	// Both of them, by name. This is the state the real shelf is in today, so the
+	// message is the thing somebody acts on.
+	for _, want := range []string{"anchorctl-linux-amd64", "anchord-darwin-arm64"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error should name %s; it said: %v", want, err)
+		}
+	}
+}
+
+func TestFetchRefusesAnUnknownFormatVersion(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+
+	base := serve(t, files, func(m *Manifest) { m.FormatVersion = 2 })
+
+	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a future manifest format should be refused rather than guessed at")
+	}
+}
+
+func TestFetchRefusesAManifestWithNoPin(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+
+	base := serve(t, files, func(m *Manifest) { m.Pin = "" })
+
+	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a manifest with no pin says nothing about which realm these are for")
+	}
+}
+
+// TestFetchRefusesAForeignURL: the manifest names its own download urls, so a shelf
+// could point them at a third party. The digest would catch substituted content; this
+// catches being sent somewhere conflux was never told about.
+func TestFetchRefusesAForeignURL(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+
+	base := serve(t, files, func(m *Manifest) {
+		m.Binaries[0].URL = "https://example.invalid/anchord-linux-amd64"
+	})
+
+	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a per-binary url on another host should be refused")
+	}
+
+	if !strings.Contains(err.Error(), "example.invalid") {
+		t.Errorf("the error should name the host; it said: %v", err)
+	}
+}
+
+func TestFetchRefusesPlainHTTPWithoutTheOverride(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+	base := serve(t, files, nil)
+
+	// serve() set the override; take it away again for this one.
+	t.Setenv(insecureEnv, "")
+
+	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a plain-http shelf should be refused unless the override is set")
+	}
+
+	if !strings.Contains(err.Error(), "plain http") {
+		t.Errorf("the error should say why; it said: %v", err)
+	}
+}
+
+func TestFetchRefusesAShortBody(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("the whole thing")}
+
+	base := serve(t, files, func(m *Manifest) { m.Binaries[0].Bytes = 999999 })
+
+	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	if err == nil {
+		t.Fatal("a body shorter than the manifest promises should be refused")
+	}
+
+	if !strings.Contains(err.Error(), "bytes") {
+		t.Errorf("the error should name the length; it said: %v", err)
+	}
+}
+
+func TestFetchReportsTheRealm(t *testing.T) {
+	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+	base := serve(t, files, nil)
+
+	var lines []string
+	log := func(format string, a ...any) { lines = append(lines, fmt.Sprintf(format, a...)) }
+
+	if err := Fetch(context.Background(), base, keys(files), t.TempDir(), log); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// The realm these binaries are pinned to decides which tree a conflux built from
+	// them can ever join, so it belongs in front of whoever ran the build.
+	if !strings.Contains(strings.Join(lines, "\n"), "realmtestpin") {
+		t.Errorf("the pin was not reported; the output was:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+
+	return out
+}

--- a/internal/shelf/shelf_test.go
+++ b/internal/shelf/shelf_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -82,6 +83,16 @@ func TestFetchWritesVerifiedBinaries(t *testing.T) {
 		}
 
 		// Executable, because the whole point is that libexec extracts and runs it.
+		//
+		// Not on Windows: Go maps a file mode to the read-only attribute there, so
+		// Perm() never reports an executable bit and this would fail on every run for
+		// a reason that has nothing to do with the fetch. internal/config's atomic
+		// tests skip for the same reason and say the same thing -- mode bits are not
+		// meaningful on windows, the DACL is.
+		if runtime.GOOS == "windows" {
+			continue
+		}
+
 		info, err := os.Stat(filepath.Join(dir, name))
 		if err != nil {
 			t.Fatal(err)

--- a/scripts/anchor-bins.sh
+++ b/scripts/anchor-bins.sh
@@ -96,7 +96,17 @@ if [ -z "$src" ] && [ "$FETCH" = 1 ]; then
     exit 0
   fi
 
-  echo "anchor-bins: the fetch failed; falling back to placeholders" >&2
+  # No fallback. FETCH=1 is somebody asking for the real binaries, so quietly writing
+  # placeholders instead would answer a different question -- and it buries the useful
+  # error: the fetcher has just printed which binaries the shelf is missing, and a
+  # fallback puts "anchor/bin holds placeholders" underneath it as the last word. The
+  # message somebody acts on should be the one they end up reading.
+  #
+  # Leave the placeholder path for when nothing was asked for, which is what lets a
+  # machine with no anchor and no network still run gofmt and the unit tests.
+  echo "anchor-bins: the fetch failed and FETCH=1 asked for real binaries, so this is fatal" >&2
+  echo "anchor-bins: drop FETCH=1 to build against placeholders instead" >&2
+  exit 1
 fi
 
 if [ -z "$src" ]; then

--- a/scripts/anchor-bins.sh
+++ b/scripts/anchor-bins.sh
@@ -7,16 +7,30 @@
 #
 #   make anchor-bins                      from ../anchor
 #   make anchor-bins ANCHOR_SRC=/path     from somewhere else
+#   make anchor-bins FETCH=1              from the published shelf, no checkout needed
 #
-# With no anchor checkout available it writes placeholders instead, which is what
-# lets CI run gofmt, vet, staticcheck and the unit tests on a machine that has no
-# access to the real ones. A conflux built from placeholders compiles, reports that
-# it carries no anchor binaries, and is caught by the size gate in `make dist` --
-# it cannot be mistaken for a shippable build.
+# Three sources, in that order of preference. A local release/ is the pinned build and
+# wins outright. A local dist/ is the unpinned development cross-build and is taken
+# loudly. With neither, FETCH=1 downloads the pinned binaries from the shelf and
+# verifies every digest -- which is what lets CI, and a fresh clone, have the real ones
+# without a checkout and without a credential.
+#
+# With no source at all it writes placeholders, which is what lets gofmt, vet,
+# staticcheck and the unit tests run on a machine with no access to any of the above. A
+# conflux built from placeholders compiles, reports that it carries no anchor binaries,
+# and is caught by the size gate in `make dist` -- it cannot be mistaken for a
+# shippable build.
 set -euo pipefail
 
 ANCHOR_SRC=${ANCHOR_SRC:-../anchor}
 DEST=${DEST:-anchor/bin}
+
+# Opt-in rather than automatic, for now. Every macOS and Windows CI job runs this and
+# needs only the two files its own build tag names, so fetching all fourteen there
+# would move 284 MB to compile 43. Once the shelf serves every target and the per-target
+# narrowing exists, this default is one line to flip.
+FETCH=${FETCH:-0}
+SHELF_URL=${SHELF_URL:-}
 
 TARGETS="linux-amd64 linux-arm64 darwin-arm64 windows-amd64 windows-arm64 freebsd-amd64 openbsd-amd64"
 
@@ -64,6 +78,26 @@ conflux: no anchor binaries, and this file is a placeholder so the module compil
 Run `make anchor-bins ANCHOR_SRC=/path/to/anchor` with a real checkout to replace it.
 EOF
 }
+
+# No local build, so try the shelf before giving up. `go run` rather than curl: this
+# repository's one stated dependency is Go, and a fresh clone should not have to acquire
+# a JSON parser to become buildable. The fetcher imports nothing that embeds anything,
+# so it still runs when anchor/bin is empty -- which is the only moment it is wanted.
+if [ -z "$src" ] && [ "$FETCH" = 1 ]; then
+  echo "anchor-bins: no local anchor build; fetching the pinned binaries from the shelf" >&2
+
+  args=""
+  [ -n "$SHELF_URL" ] && args="-url $SHELF_URL"
+
+  # $want is the same list the prune above is built from, so there is one definition of
+  # what belongs here rather than two that can disagree.
+  if go run ./cmd/anchor-fetch $args -dest "$DEST" -want "$(echo $want | tr ' ' ',')"; then
+    echo "anchor-bins: $TOTAL/$TOTAL fetched from the shelf (pinned release build)"
+    exit 0
+  fi
+
+  echo "anchor-bins: the fetch failed; falling back to placeholders" >&2
+fi
 
 if [ -z "$src" ]; then
   echo "anchor-bins: no anchor build found under $ANCHOR_SRC (looked for release/ and dist/)" >&2

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Two conflux nodes, one taint, reaching each other over the overlay.
+# Three conflux nodes, one taint, reaching each other over the overlay.
 #
-# This enrols twice against the live API. That is deliberate and cheap: the route is
-# anonymous, stores nothing, and the taint below is random -- so the two nodes sit in
-# a compartment of their own and can exchange data with nobody else in the realm.
+# This enrols three times against the live API. That is deliberate and cheap: the
+# route is anonymous, stores nothing, and the taint below is random -- so the nodes
+# sit in a compartment of their own and can exchange data with nobody else in the
+# realm.
+#
+# The third node is the LAN-discovery control and joins late; everything before it is
+# the two-node test this file has always been.
 set -euo pipefail
 
 IMAGE=${IMAGE:-conflux-systemd-test}
@@ -26,7 +30,25 @@ boot() {
 
 anchor_id() { docker exec "$1" sh -c "sed -n 's/.*\"anchorId\": \"\([^\"]*\)\".*/\1/p' /var/lib/conflux/state.json"; }
 
-trap 'docker rm -f cfx-a cfx-b >/dev/null 2>&1 || true' EXIT
+# lan_found sums anchor_lan_peers_found_total across whatever labels it carries -- the
+# counter is per-interface, and a container with two bridges would otherwise be read
+# as only the first of them. `conflux metrics` is the anchorctl pass-through, and its
+# format is "name<two spaces>value"; see internal/anchorctl.ParseMetrics.
+lan_found() {
+  docker exec "$1" conflux metrics 2>/dev/null |
+    awk '$1 ~ /^anchor_lan_peers_found_total/ { s += $2 } END { print s + 0 }'
+}
+
+# Reaped before as well as after. The trap does not fire when a CI run is cancelled
+# -- the runner's SIGTERM ends bash without it, and SIGKILL is not catchable at all --
+# and the runner is no longer a machine that is thrown away afterwards, so a cancelled
+# run leaves three fixed names for the next run to collide with. `docker rm -f` shrugs
+# at a name that is not there, so this is a no-op on a clean machine.
+before=$(docker ps -aq | wc -l)
+docker rm -f cfx-a cfx-b cfx-c >/dev/null 2>&1 || true
+echo "containers on this machine: $before before this run"
+
+trap 'docker rm -f cfx-a cfx-b cfx-c >/dev/null 2>&1 || true' EXIT
 
 say "taint for this run: $TAINT"
 
@@ -65,6 +87,42 @@ docker exec cfx-a ping -c3 -W3 10.128.0.2
 docker exec cfx-b ping -c3 -W3 10.128.0.1
 B6=$(docker exec cfx-b sh -c "ip -o -6 addr show anchor0 scope global | awk '{print \$4}' | cut -d/ -f1")
 docker exec cfx-a ping -c2 -W3 "$B6"
+
+# Both containers sit on one Docker bridge, which is a real link with a real
+# multicast-capable kernel -- the one thing no Go test in this tree can arrange. So
+# the probe is live here whether or not anything was configured to use it.
+#
+# Non-zero rather than present, and that is the whole assertion. The series is created
+# the first time it is written, delta included, so the name appears at zero as soon as
+# an anchor polls -- a grep for the name alone passes on an anchor that never found a
+# thing. anchor's own suite records being caught by exactly that.
+say "the realm was found on the link, not only through the bootstrap list"
+for i in $(seq 12); do
+  [ "$(lan_found cfx-a)" -gt 0 ] && { echo "discovery counter moved after ~$((i * 5))s"; break; }
+  sleep 5
+done
+[ "$(lan_found cfx-a)" -gt 0 ] \
+  || { echo "anchor_lan_peers_found_total never moved on A, so nothing was found on the link" >&2; exit 1; }
+
+# The control, and the reason it is worth three enrolments. C names no --peers at all,
+# so if it reaches the realm it did so from the manifest's own bootstrap list -- which
+# is what proves discovery is a third source and not a load-bearing one. And its
+# counter must stay at zero, which is what proves --lan-discovery no reached anchor
+# rather than being accepted by conflux and dropped on the floor.
+say "node C joins with --lan-discovery no and no bootstrap list of its own"
+boot cfx-c
+docker exec cfx-c conflux up --taint "$TAINT" --ipv4 10.128.0.3/24 --lan-discovery no
+
+for _ in $(seq 12); do
+  docker exec cfx-a ping -c1 -W2 10.128.0.3 >/dev/null 2>&1 && break
+  sleep 10
+done
+docker exec cfx-a ping -c3 -W3 10.128.0.3 \
+  || { echo "C never joined, so the manifest's own bootstrap list is not carrying a node on its own" >&2; exit 1; }
+
+[ "$(lan_found cfx-c)" -eq 0 ] \
+  || { echo "C probed the link despite --lan-discovery no: the flag did not reach anchor" >&2; exit 1; }
+echo "C found the realm without probing, and A did probe: discovery is additive"
 
 say "reboot A: it must come back by itself, same identity"
 docker restart cfx-a >/dev/null

--- a/test/preflight.sh
+++ b/test/preflight.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# What the machine has to give the container suites, said before anything is built.
+#
+# All four of these are properties of the runner rather than of this repository, and
+# every one of them fails later and less legibly than it does here: no IPv6 arrives as
+# a ping assertion eleven minutes in, no /dev/net/tun as an anchor that will not come
+# up, no cgroup v2 as a container whose systemd never reaches "running". Printing them
+# on a green run is the point as much as failing on a red one -- a suite that needs a
+# privileged container should say what it was given.
+set -euo pipefail
+
+fail=0
+note() { printf '  %-12s %s\n' "$1" "$2"; }
+bad() { echo "::error::$1" >&2; fail=1; }
+
+echo "what this runner gives the suite:"
+
+if docker info >/dev/null 2>&1; then
+  note docker "$(docker --version 2>&1)"
+else
+  bad "the Docker daemon does not answer; every suite here runs in containers"
+fi
+
+if [ -c /dev/net/tun ]; then
+  note tun "/dev/net/tun present"
+else
+  bad "no /dev/net/tun; conflux up brings up a TUN interface and cannot without it"
+fi
+
+# A writable host cgroup mount is what lets systemd run as PID 1 in a container. The
+# version is reported and not required: the image was measured booting in two seconds
+# on a v1 host, so failing v1 here would reject a machine the suite works on. What
+# cannot be worked around is the mount not being there at all.
+if [ -d /sys/fs/cgroup ]; then
+  if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    note cgroups "v2 (unified)"
+  else
+    note cgroups "v1 -- workable; the suite mounts it into the container either way"
+  fi
+else
+  bad "no /sys/fs/cgroup to bind-mount; the test image boots systemd as PID 1 and needs it"
+fi
+
+# Every overlay address is an IPv6 ULA, and integration.sh pings one directly. A
+# kernel without IPv6 brings the anchor up and fails the assertion much later.
+if [ -e /proc/net/if_inet6 ]; then
+  note ipv6 "present ($(wc -l < /proc/net/if_inet6) addresses on the host)"
+else
+  bad "this runner has no IPv6; every overlay address is an IPv6 ULA"
+fi
+
+# Not a requirement, only worth knowing: enrolment is an ordinary HTTPS POST, and a
+# machine that cannot reach the API fails at the first `conflux up` rather than here.
+if curl -fsS -o /dev/null --max-time 10 https://api.veilnet.com.au/docs 2>/dev/null; then
+  note api "api.veilnet.com.au reachable"
+else
+  note api "api.veilnet.com.au NOT reachable -- enrolment will fail"
+fi
+
+exit $fail

--- a/test/service.sh
+++ b/test/service.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# The boot service, in a container that actually boots systemd.
+#
+# install registers the unit and does not start it; uninstall leaves nothing behind.
+# Neither assertion enrols, so this runs without touching the API -- which is what
+# makes it the cheap one to run when the question is only about the unit.
+#
+# Restarting the container is the reboot, and that half lives in integration.sh
+# because proving a machine comes back needs a machine that was up.
+set -euo pipefail
+
+IMAGE=${IMAGE:-conflux-systemd-test}
+NAME=${NAME:-cfx}
+
+say() { printf '\n== %s\n' "$*"; }
+
+# Before as well as after. The trap below does not fire when a CI run is cancelled --
+# the runner's SIGTERM ends bash without it, and SIGKILL is not catchable at all --
+# and on a machine that is not thrown away afterwards that leaves a name the next run
+# collides with, for a reason that has nothing to do with the commit under test.
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+trap 'docker rm -f "$NAME" >/dev/null 2>&1 || true' EXIT
+
+say "a container that boots systemd"
+docker run -d --name "$NAME" --privileged --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw --device /dev/net/tun "$IMAGE" >/dev/null
+
+for _ in $(seq 40); do
+  [ "$(docker exec "$NAME" systemctl is-system-running 2>/dev/null)" = running ] && break
+  sleep 1
+done
+[ "$(docker exec "$NAME" systemctl is-system-running 2>/dev/null)" = running ] \
+  || { echo "systemd did not come up" >&2; exit 1; }
+
+say "install registers without inventing a configuration"
+docker exec "$NAME" conflux install
+[ "$(docker exec "$NAME" systemctl is-enabled conflux.service)" = enabled ] \
+  || { echo "install did not enable the unit" >&2; exit 1; }
+
+# The half that is easy to regress: install must register and not start. A machine
+# with no configuration has nothing to start, and an install that started anyway
+# would spend the unit's ninety seconds failing before saying so.
+[ "$(docker exec "$NAME" systemctl is-active conflux.service)" = inactive ] \
+  || { echo "install started the service; it must only register" >&2; exit 1; }
+
+say "uninstall leaves nothing"
+docker exec "$NAME" conflux uninstall --yes
+docker exec "$NAME" sh -c 'test ! -f /etc/systemd/system/conflux.service' \
+  || { echo "the unit file survived uninstall" >&2; exit 1; }
+docker exec "$NAME" sh -c 'test ! -d /var/lib/conflux' \
+  || { echo "the state directory survived uninstall" >&2; exit 1; }
+
+say "all assertions passed"


### PR DESCRIPTION
`docs/testing.md` has said what to do here for as long as the file has existed:

> When `anchor/bin` gains a source CI can reach, remove the `if:` on those two jobs.

It has one now — the shelf. `make anchor-bins FETCH=1` fetches the **pinned** anchor binaries from `GET /anchor/release`, verifies every digest, and writes `anchor/bin`. **No anchor checkout, no credential.**

## What this does

**`service` and `integration` are no longer `workflow_dispatch` only.** Neither could have worked on a dispatch either: both went straight to `make dist` with no `anchor-bins` step, so `//go:embed` had nothing to embed and the build failed before the size gate could say why.

**The `linux` gate gets the real binaries too**, which starts eight tests that had only ever run on a developer's machine — both header checks in `anchor/`, the four `libexec` extraction tests, the anchorctl flag cross-check, and the shadowing check in `internal/cli`. A skip is green, so the job now asserts afterwards that none of them skipped.

**They're the pinned build.** A local `make dist` is unpinned and joins any realm tree; what the shelf serves refuses to handshake with anything but the genesis. So `integration` exercises the binaries that actually ship.

**`--lan-discovery yes|no|auto`** — the fifth setting anchor has had all along that conflux wouldn't pass. A tristate spelled the way anchorctl spells it, because `auto` is the only value that passes no flag, which is what leaves the manifest in play. Only an explicit `yes` is refused beside `--uplink`, mirroring anchor's own rule.

## Why the shelf rather than a token

An earlier revision had CI check anchor out with a `Contents: read` token. That works, and it's the wrong size: it hands over the whole source tree to obtain fourteen files. Those fourteen aren't secret — `//go:embed` puts these exact bytes inside every published conflux, so anyone who downloads a release already has them. conflux needs anchor's *output*, and the output isn't the secret. **anchor's source never leaves anchor, and no secret is needed in a public repo.**

Six refusals in the fetcher, each with a test, each a thing that would otherwise pass silently:

| refuses | because |
|---|---|
| a digest that doesn't match | the failure nothing downstream catches — a real binary of the right size clears the size gate, and one of the right architecture clears `TestPairIsRealExecutables` |
| `anchoradmin` on the shelf | it mints realm roots, and every file in `anchor/bin` is a candidate for embedding into every conflux a user runs |
| a per-binary `url` on another host | the digest catches substituted content; this catches being sent somewhere conflux was never told about |
| a manifest with no `pin` | nothing then says which realm these are for |
| an unknown `formatVersion` | a future shape may mean anything |
| a short body, or plain http | a truncated download, and an unencrypted one |

## ⚠️ What's needed before this goes green

**The shelf serves 2 of the 14.** `linux`, `service` and `integration` will fail naming the other twelve, one per line, because that message is the thing somebody acts on:

```
anchor-fetch: the shelf serves 2 of the 14 binaries conflux embeds; missing:
  anchorctl-darwin-arm64
  anchorctl-freebsd-amd64
  …
```

Widening it to all seven platforms × two programs is the only remaining blocker. `GENESIS_PIN` is now set on anchor, and `make release` needs **only the pin, never the private key** — verified: with just `genesis/genesis.pin` present, the mint rule correctly does not fire and no key is created.

One thing to watch on the first anchor release run: **garble cannot patch a toolchain-managed Go.** If `GOROOT` sits under `GOMODCACHE`, the linker overlay is refused and `make release` dies in garble. `actions/setup-go` installs into the tool cache instead, so veilnet-dev should be fine — but that's the first thing to check if it fails.

## Verified locally

| | |
|---|---|
| all packages, real binaries | pass, **zero skips**, 76 tests |
| `internal/shelf` | 10 tests over `httptest` |
| the fetcher against the **real** shelf | fetches both linux/amd64 binaries, digests match `sha256sum` independently |
| `make race`, `fmtcheck`, `vet`, `tidycheck` | pass |
| `make cross` | all seven targets |
| `make dist` | 54–58 MB per artifact — first time the 30–75 MB gate has had anything real to gate |
| `make service-test` | **passes end to end** in a container that boots systemd |
| `make integration` | **needs the runner** — no IPv6 here, and a container can't reach the API |

## Two premises worth correcting

- **`anchorctl kill` is not a forceful stop** and has nothing to do with `conflux down`. It makes another anchor *a realm-wide target* (`-target ANCHORID -days N`), needs an `-admin` credential, travels by gossip, and nothing can end it early. `down` already does the right thing.
- **LAN discovery cannot skip enrolment.** The probe is sealed under the realm's *root public key*, which a machine holds only after enrolling. It decides who is worth dialling, never who is let in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WycftHLnK63RCNsVUh3Kg