### PR TITLE
Fetch the anchor pair from anchor's release, and say what that costs

### DIFF
--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -1,31 +1,42 @@
 name: anchor-bins
 description: >
-  Populate anchor/bin with the pinned anchor binaries, fetched from the published
-  release shelf. No checkout of anchor, and no credential.
+  Populate anchor/bin with the pinned anchor binaries, fetched from the `shelf` release
+  of veil-net/anchor.
 
 inputs:
-  url:
+  token:
     description: >
-      The release manifest. Defaults to the one internal/shelf names, so the value is
-      stated once in the product code rather than twice.
+      A GitHub token with Contents: read on veil-net/anchor. Required: anchor is private,
+      and GitHub has no releases-only read scope, so reading two binaries and reading the
+      source are the same grant. Pass secrets.ANCHOR_RELEASE_TOKEN.
+    required: true
+  repo:
+    description: >
+      The owner/name holding the release. Defaults to what internal/shelf names, so the
+      value is stated once in the product code rather than twice.
+    required: false
+    default: ""
+  tag:
+    description: The release tag. Defaults to what internal/shelf names.
     required: false
     default: ""
 
 runs:
   using: composite
   steps:
-    # What this fetches is what conflux already ships: //go:embed puts these bytes
-    # inside every published conflux, so a public shelf discloses nothing a release
-    # download does not. That is why this needs no token for a private repository --
-    # conflux wants anchor's *output*, and the output is not the secret.
+    # What this fetches is the *pinned* build, which a local `make dist` cannot be: an
+    # anchor pinned to the genesis realm refuses to handshake with any other tree. So the
+    # container suites exercise the binaries that actually ship.
     #
-    # And what it fetches is the *pinned* build, which a local `make dist` cannot be:
-    # an anchor pinned to the genesis realm refuses to handshake with any other tree.
-    # So the container suites below now exercise the binaries that actually ship.
+    # The token reaches the fetcher as an environment variable and never as an argument:
+    # an argument is visible in `ps` to every other user on the machine, and this runs on
+    # a machine that is not destroyed at the end of the job.
     - name: fetch the pinned anchor binaries
       shell: bash
       env:
-        SHELF_URL: ${{ inputs.url }}
+        ANCHOR_RELEASE_TOKEN: ${{ inputs.token }}
+        ANCHOR_REPO: ${{ inputs.repo }}
+        ANCHOR_TAG: ${{ inputs.tag }}
       run: make anchor-bins FETCH=1
 
     # Say what arrived, because a green tick on fourteen files nobody looked at is worth

--- a/.github/actions/anchor-bins/action.yml
+++ b/.github/actions/anchor-bins/action.yml
@@ -4,11 +4,14 @@ description: >
   of veil-net/anchor.
 
 inputs:
-  token:
+  app-id:
     description: >
-      A GitHub token with Contents: read on veil-net/anchor. Required: anchor is private,
-      and GitHub has no releases-only read scope, so reading two binaries and reading the
-      source are the same grant. Pass secrets.ANCHOR_RELEASE_TOKEN.
+      The App ID of the GitHub App that can read anchor. Pass secrets.ANCHOR_APP_ID.
+    required: true
+  private-key:
+    description: >
+      That App's private key, whole, including its BEGIN and END lines. Pass
+      secrets.ANCHOR_APP_PRIVATE_KEY.
     required: true
   repo:
     description: >
@@ -24,6 +27,32 @@ inputs:
 runs:
   using: composite
   steps:
+    # A GitHub App rather than a personal access token, for three reasons that are all
+    # about the credential rather than about what it can read -- the data is the same
+    # either way, because GitHub has no releases-only scope and Contents: read grants
+    # anchor's source too.
+    #
+    #   1. What is stored here is not a credential. A PAT in a repository secret *is* the
+    #      key; this is a private key that has to be exchanged for one, so the secret on
+    #      its own opens nothing.
+    #   2. The token it mints lasts an hour and is revoked when the job ends, rather than
+    #      being valid until somebody notices.
+    #   3. It does not expire and belongs to no person, so it does not break a year from
+    #      now, and it does not die when somebody leaves.
+    #
+    # owner and repositories are both required to be correct rather than merely present.
+    # Without them the action mints a token for the *calling* repository -- conflux --
+    # which can read conflux perfectly and anchor not at all, and the failure arrives as a
+    # 404 on the release, which reads like a missing tag.
+    - name: mint a token that can read anchor
+      id: app
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: veil-net
+        repositories: anchor
+
     # What this fetches is the *pinned* build, which a local `make dist` cannot be: an
     # anchor pinned to the genesis realm refuses to handshake with any other tree. So the
     # container suites exercise the binaries that actually ship.
@@ -34,7 +63,7 @@ runs:
     - name: fetch the pinned anchor binaries
       shell: bash
       env:
-        ANCHOR_RELEASE_TOKEN: ${{ inputs.token }}
+        ANCHOR_RELEASE_TOKEN: ${{ steps.app.outputs.token }}
         ANCHOR_REPO: ${{ inputs.repo }}
         ANCHOR_TAG: ${{ inputs.tag }}
       run: make anchor-bins FETCH=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,12 @@ permissions:
 # warning on the "Allow public repositories" checkbox is about, and why that checkbox
 # exists separately from repository access at all.
 #
-# Fetching from the shelf rather than checking anchor out removes the sharpest version
-# of that -- there is no private source on the machine and no token in this repository's
-# secrets to reach for -- but the guard stays, because running a stranger's code on a
-# persistent machine is worth refusing on its own.
+# Fetching the release rather than checking anchor out removes the sharpest version of
+# that -- there is no private source tree on the machine -- but there *is* now a
+# credential here, so the guard matters more than it did, not less. GitHub does not pass
+# secrets to a fork's pull request, which is the mechanism; this refusal is the belt
+# beside it, because running a stranger's code on a machine that survives the job is
+# worth refusing on its own.
 #
 # So nothing a fork writes executes on veilnet-dev at all. This lives here rather than in
 # a setting because a setting cannot express it — "Allow public repositories" is
@@ -59,12 +61,17 @@ permissions:
 # after: a cancelled run fires neither an EXIT trap nor an `if: always()` step.
 #
 # What makes `service` and `integration` runnable at all, though, is not the machine --
-# it is the shelf. docs/testing.md said those two needed the real anchor binaries, which
-# "a runner has no way to fetch", and that was true only while the binaries had no
-# published source. They have one now: `make anchor-bins FETCH=1` downloads the pinned
-# release build from api.veilnet.com.au and verifies every digest, with no anchor
-# checkout and no credential. So both jobs lose their `workflow_dispatch` gate, and the
-# `linux` gate gets the real binaries too.
+# it is that the binaries have a published source. docs/testing.md said those two needed
+# the real anchor binaries, which "a runner has no way to fetch", and that was true only
+# while no such source existed. One does now: `make anchor-bins FETCH=1` downloads the
+# pinned build from anchor's `shelf` release and verifies every digest, with no anchor
+# checkout. So both jobs lose their `workflow_dispatch` gate, and the `linux` gate gets
+# the real binaries too.
+#
+# It does need a credential, since anchor is private. A GitHub App rather than a personal
+# access token: what is stored in this repository is a private key that has to be
+# exchanged for a token, so the secret alone opens nothing, and the token it mints lasts
+# an hour. See .github/actions/anchor-bins.
 #
 # And it is one machine. With a single runner process these four Linux jobs queue rather
 # than run side by side, so a push costs the sum of them instead of the longest — which
@@ -97,7 +104,8 @@ jobs:
       # why this was easy not to notice.
       - uses: ./.github/actions/anchor-bins
         with:
-          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
+          app-id: ${{ secrets.ANCHOR_APP_ID }}
+          private-key: ${{ secrets.ANCHOR_APP_PRIVATE_KEY }}
 
       - run: make fmtcheck
       - run: make vet
@@ -261,7 +269,8 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/anchor-bins
         with:
-          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
+          app-id: ${{ secrets.ANCHOR_APP_ID }}
+          private-key: ${{ secrets.ANCHOR_APP_PRIVATE_KEY }}
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh
@@ -293,7 +302,8 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/anchor-bins
         with:
-          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
+          app-id: ${{ secrets.ANCHOR_APP_ID }}
+          private-key: ${{ secrets.ANCHOR_APP_PRIVATE_KEY }}
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,16 @@
 name: ci
 
+# No push trigger on main, deliberately.
+#
+# main is covered by release.yml, which calls this workflow and then publishes. If both
+# ran on a push to main the whole suite would run twice on one commit, serialised on the
+# one runner everything else queues behind.
+#
+# version3 stays, because nothing else covers it: it is the integration branch, and a
+# merge there is not a release.
 on:
   push:
-    branches: [main, version3]
+    branches: [version3]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       # cross-check, and the shadowing check in internal/cli. A skip is green, which is
       # why this was easy not to notice.
       - uses: ./.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
 
       - run: make fmtcheck
       - run: make vet
@@ -258,6 +260,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh
@@ -288,6 +292,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
 
       - name: what this runner gives the suite
         run: ./test/preflight.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,26 +16,27 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Read by default; `build` raises its own. Nothing else here, including the whole of
+# ci.yml called below, can create a release or sign anything.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  # Is there a release to make? Asked first, because the answer is usually no.
+  # Is there a release to make? Asked cheaply, because the answer is usually no.
   #
-  # Every merge to main runs this workflow, and most merges do not change VERSION. Without
-  # this job each of them would pay the full suite and seven cross-builds before
-  # discovering there was nothing to publish -- on the one runner everything else queues
-  # behind.
+  # Every merge to main runs this workflow and most merges do not change VERSION, so
+  # without this each of them would cross-build seven targets, attest them and publish
+  # before anything noticed there was nothing new to ship.
+  #
+  # It gates `verify` and `build` and deliberately not `tests` -- the suite has to run on
+  # every merge either way.
   #
   # The branch is named here as well as in the trigger, because `workflow_dispatch` above
-  # is not restricted to main and nothing else in this file would stop it. Every job below
-  # needs this one, directly or through another, so a skip here skips all of them.
+  # is not restricted to main and nothing else in this file would stop it.
   gate:
     if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, linux]
@@ -85,20 +86,15 @@ jobs:
             echo "Bump VERSION and merge to main to cut the next one."
           fi
 
-  # Everything ci.yml checks, before anything here ships.
+  # Everything ci.yml checks, on the merged commit, before anything here ships.
   #
-  # A tag push runs none of ci.yml's own triggers, so until this a release was gated on
-  # nothing: `verify` below asks whether the binaries about to be embedded are real, and
-  # nothing asked whether the code around them still worked. The tag is usually cut from
-  # a commit that was green on main, which is a convention rather than a check -- and the
-  # one release where it is not true is the one nobody wants to find out about from a
-  # user.
+  # Not gated on the version. ci.yml no longer triggers on main itself, so this is the
+  # only thing that tests a merge there, and a merge that does not bump VERSION still has
+  # to be correct.
   #
   # Calling ci.yml rather than repeating its steps: a second copy of the gate is a copy
   # that drifts, and the half that drifts is always the one nobody is watching.
   tests:
-    needs: gate
-    if: needs.gate.outputs.release == 'true'
     uses: ./.github/workflows/ci.yml
 
     # Without this the called workflow gets no secrets at all -- they are not inherited
@@ -109,6 +105,10 @@ jobs:
 
   verify:
     needs: [gate, tests]
+
+    # Here rather than on `tests`: the suite runs on every merge, and only publishing is
+    # conditional on the tree claiming a version nobody has released.
+    if: needs.gate.outputs.release == 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
@@ -173,6 +173,13 @@ jobs:
   build:
     needs: [gate, verify]
     runs-on: [self-hosted, linux]
+
+    # The only job that writes. contents to create the release, the other two for the
+    # build-provenance attestation.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
   tests:
     uses: ./.github/workflows/ci.yml
 
+    # Without this the called workflow gets no secrets at all -- they are not inherited
+    # by default -- and every anchor-bins step inside it would fail on a token that is
+    # set here and empty there. A called workflow is a different workflow, and the only
+    # sign of the difference is that nothing works.
+    secrets: inherit
+
   verify:
     needs: tests
     runs-on: [self-hosted, linux]
@@ -43,6 +49,8 @@ jobs:
       # runner needs a source for them". That source exists now, which is the whole of
       # what made a conflux release possible from CI rather than from a laptop.
       - uses: ./.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
 
       # A second opinion on what the fetcher just wrote. It already refuses anchoradmin,
       # verifies every digest, and fails rather than falling back -- so these three now
@@ -101,6 +109,8 @@ jobs:
       # release carries whatever anchor published most recently, which is the intent:
       # conflux ships the newest anchor, not a remembered one.
       - uses: ./.github/actions/anchor-bins
+        with:
+          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
 
       # All seven targets, not just this runner's: linux amd64 and arm64, darwin arm64,
       # windows amd64 and arm64, freebsd and openbsd. CGO_ENABLED=0 throughout, so one

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,19 @@
 name: release
 
+# A merge to main, and nothing else.
+#
+# It was a tag push, which made cutting a release a separate manual act performed on a
+# commit nobody had necessarily released from -- and a `workflow_dispatch` with no branch
+# condition meant running this by hand on a feature branch built `make dist
+# VERSION=<branch-name>` and published it to the public as a GitHub release.
+#
+# Now the tree decides. VERSION is a file, the gate below reads it, and a release happens
+# exactly when somebody bumps that file and the change reaches main. The tag becomes a
+# consequence of the merge rather than a second thing to remember, and there is no branch
+# from which a release can be produced at all.
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +26,65 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Is there a release to make? Asked first, because the answer is usually no.
+  #
+  # Every merge to main runs this workflow, and most merges do not change VERSION. Without
+  # this job each of them would pay the full suite and seven cross-builds before
+  # discovering there was nothing to publish -- on the one runner everything else queues
+  # behind.
+  #
+  # The branch is named here as well as in the trigger, because `workflow_dispatch` above
+  # is not restricted to main and nothing else in this file would stop it. Every job below
+  # needs this one, directly or through another, so a skip here skips all of them.
+  gate:
+    if: github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, linux]
+    outputs:
+      release: ${{ steps.decide.outputs.release }}
+      version: ${{ steps.decide.outputs.version }}
+      tag: ${{ steps.decide.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: does this tree claim a version that is not published?
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          [ -s VERSION ] || { echo "::error::VERSION is missing or empty" >&2; exit 1; }
+
+          version=$(tr -d '[:space:]' < VERSION)
+          tag="v$version"
+
+          # A 404 means no release at that tag, which is the case worth acting on. Any
+          # other code is asked about rather than assumed: treating a 500 as "not
+          # published" would republish a version that already exists.
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$tag")
+
+          case "$code" in
+            404) release=true ;;
+            200) release=false ;;
+            *)   echo "::error::GitHub answered $code asking about $tag; refusing to guess" >&2; exit 1 ;;
+          esac
+
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "release=$release"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$release" = true ]; then
+            echo "$tag is not published yet -- building it"
+          else
+            echo "$tag is already published; nothing to do"
+            echo "Bump VERSION and merge to main to cut the next one."
+          fi
+
   # Everything ci.yml checks, before anything here ships.
   #
   # A tag push runs none of ci.yml's own triggers, so until this a release was gated on
@@ -27,6 +97,8 @@ jobs:
   # Calling ci.yml rather than repeating its steps: a second copy of the gate is a copy
   # that drifts, and the half that drifts is always the one nobody is watching.
   tests:
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     uses: ./.github/workflows/ci.yml
 
     # Without this the called workflow gets no secrets at all -- they are not inherited
@@ -36,7 +108,7 @@ jobs:
     secrets: inherit
 
   verify:
-    needs: tests
+    needs: [gate, tests]
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
@@ -99,7 +171,7 @@ jobs:
           exit $missing
 
   build:
-    needs: verify
+    needs: [gate, verify]
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v7
@@ -117,7 +189,11 @@ jobs:
       # All seven targets, not just this runner's: linux amd64 and arm64, darwin arm64,
       # windows amd64 and arm64, freebsd and openbsd. CGO_ENABLED=0 throughout, so one
       # Linux machine cross-builds every one of them.
-      - run: make dist VERSION=${{ github.ref_name }}
+      # No VERSION= override. The Makefile reads the VERSION file, which is what the gate
+      # above read to decide there was anything to build -- so the number in the binary and
+      # the number on the release cannot disagree. Passing github.ref_name here would set
+      # it to the branch name now that this runs on a merge rather than a tag.
+      - run: make dist
 
       - uses: actions/attest-build-provenance@v1
         with:
@@ -139,8 +215,15 @@ jobs:
             grep -E 'Version|ZipSHA256' internal/wintun/pinned.go | sed 's/^\s*/  /'
           } > notes.md
 
+      # The tag is created here, at this commit, from the version the tree claims. That
+      # ordering is the point: the tag marks a commit that has already passed the whole of
+      # ci.yml and produced these seven binaries, rather than being a promise made before
+      # any of it ran.
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.gate.outputs.tag }}
+          name: ${{ needs.gate.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           files: |
             dist/conflux-*
             dist/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
       # what made a conflux release possible from CI rather than from a laptop.
       - uses: ./.github/actions/anchor-bins
         with:
-          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
+          app-id: ${{ secrets.ANCHOR_APP_ID }}
+          private-key: ${{ secrets.ANCHOR_APP_PRIVATE_KEY }}
 
       # A second opinion on what the fetcher just wrote. It already refuses anchoradmin,
       # verifies every digest, and fails rather than falling back -- so these three now
@@ -110,7 +111,8 @@ jobs:
       # conflux ships the newest anchor, not a remembered one.
       - uses: ./.github/actions/anchor-bins
         with:
-          token: ${{ secrets.ANCHOR_RELEASE_TOKEN }}
+          app-id: ${{ secrets.ANCHOR_APP_ID }}
+          private-key: ${{ secrets.ANCHOR_APP_PRIVATE_KEY }}
 
       # All seven targets, not just this runner's: linux amd64 and arm64, darwin arm64,
       # windows amd64 and arm64, freebsd and openbsd. CGO_ENABLED=0 throughout, so one

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,17 @@ MAX_MB := 75
 
 ANCHOR_SRC ?= ../anchor
 
-# FETCH=1 downloads the pinned binaries from the shelf when no local anchor build is
-# available. Opt-in for now: the macOS and Windows jobs run anchor-bins too and need
-# only the two files their own build tag names, so fetching all fourteen there would
-# move 284 MB to compile 43.
+# FETCH=1 downloads the pinned binaries from anchor's `shelf` release when no local
+# anchor build is available. Opt-in for now: the macOS and Windows jobs run anchor-bins
+# too and need only the two files their own build tag names, so fetching all fourteen
+# there would move 284 MB to compile 43.
+#
+# It needs ANCHOR_RELEASE_TOKEN, because anchor is private. The three below are empty by
+# default so the values live in internal/shelf rather than being repeated here.
 FETCH ?= 0
-SHELF_URL ?=
+ANCHOR_API ?=
+ANCHOR_REPO ?=
+ANCHOR_TAG ?=
 
 # The tag `make image` builds and the two suites run. Overridable so a second checkout
 # on one machine does not race the first for the name.
@@ -51,11 +56,13 @@ all: fmtcheck vet lint tidycheck test cross dist
 # before its first build.
 #
 # Three sources in order: a local release/ (pinned), a local dist/ (unpinned, taken
-# loudly), then with FETCH=1 the published shelf, which serves the pinned build and
-# needs no checkout and no credential. With none of them it writes placeholders, which
-# compile and are caught by the size gate in dist.
+# loudly), then with FETCH=1 anchor's `shelf` release, which serves the pinned build and
+# needs no checkout -- but does need a token, since anchor is private. With none of them
+# it writes placeholders, which compile and are caught by the size gate in dist.
 anchor-bins:
-	@ANCHOR_SRC=$(ANCHOR_SRC) FETCH=$(FETCH) SHELF_URL=$(SHELF_URL) ./scripts/anchor-bins.sh
+	@ANCHOR_SRC=$(ANCHOR_SRC) FETCH=$(FETCH) \
+		ANCHOR_API=$(ANCHOR_API) ANCHOR_REPO=$(ANCHOR_REPO) ANCHOR_TAG=$(ANCHOR_TAG) \
+		./scripts/anchor-bins.sh
 
 # CGO_ENABLED=0 here for the same reason cross and dist set it: so that the binary a
 # developer builds and installs is the same *kind* of binary as the one that ships.
@@ -182,7 +189,8 @@ help:
 	@echo "conflux"
 	@echo "  make anchor-bins populate anchor/bin (do this first)"
 	@echo "                   ANCHOR_SRC=/path/to/anchor, default ../anchor"
-	@echo "                   FETCH=1 to download the pinned binaries instead, no checkout needed"
+	@echo "                   FETCH=1 to fetch the pinned binaries from anchor's release"
+	@echo "                   (needs ANCHOR_RELEASE_TOKEN; anchor is private)"
 	@echo "  make build       build for this machine"
 	@echo "  make test        run the tests"
 	@echo "  make race        run them under the race detector"

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ GO      ?= go
 BIN     ?= bin
 DIST    ?= dist
 # VERSION is the file, not the tag. A tag is a claim about a commit; the file is a
-# claim about the tree, and it is the tree that gets built. release.yml still wins by
-# passing VERSION=<tag> on the command line, which ?= leaves it free to do.
+# claim about the tree, and it is the tree that gets built. release.yml used to override
+# it with the tag name and no longer does: it reads this same file to decide whether
+# there is a release to make, and creates the tag from it afterwards, so the number in
+# the binary and the number on the release cannot disagree. ?= still leaves it free to
+# be overridden by hand.
 VERSION ?= $(shell cat $(CURDIR)/VERSION 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 

--- a/cmd/anchor-fetch/main.go
+++ b/cmd/anchor-fetch/main.go
@@ -1,17 +1,17 @@
-// Command anchor-fetch populates anchor/bin from the published release manifest.
+// Command anchor-fetch populates anchor/bin from a release of the anchor repository.
 //
-// Invoked by scripts/anchor-bins.sh when no local anchor checkout is available, which
-// is the state CI is in and the state a fresh clone starts in.
+// Invoked by scripts/anchor-bins.sh when no local anchor checkout is available, which is
+// the state CI is in and the state a fresh clone starts in.
 //
-// Go rather than shell, and a program rather than curl piped into a JSON parser,
-// because docs/build.md promises "Go 1.27.1 or newer, and nothing else" and a fresh
-// clone should not need python or jq to become buildable. It also puts the digest
-// check, the redirect refusal and the atomic write somewhere they can be tested.
+// Go rather than shell, and a program rather than curl piped into a JSON parser, because
+// docs/build.md promises "Go 1.27.1 or newer, and nothing else" and a fresh clone should
+// not need python or jq to become buildable. It also puts the digest check, the redirect
+// rules and the atomic write somewhere they can be tested.
 //
-// Deliberately imports no package that embeds anything. `go run ./cmd/anchor-fetch`
-// has to work when anchor/bin is empty -- that is the only moment it is ever wanted --
-// so a dependency on the anchor package would make this unable to run in exactly the
-// case it exists for.
+// Deliberately imports no package that embeds anything. `go run ./cmd/anchor-fetch` has
+// to work when anchor/bin is empty -- that is the only moment it is ever wanted -- so a
+// dependency on the anchor package would make this unable to run in exactly the case it
+// exists for.
 package main
 
 import (
@@ -26,7 +26,9 @@ import (
 )
 
 func main() {
-	url := flag.String("url", shelf.DefaultURL, "the release manifest to fetch from")
+	api := flag.String("api", shelf.DefaultAPI, "the GitHub API to read the release from")
+	repo := flag.String("repo", shelf.DefaultRepo, "the owner/name holding the release")
+	tag := flag.String("tag", shelf.DefaultTag, "the release tag to fetch")
 	dest := flag.String("dest", "anchor/bin", "where to write the binaries")
 	want := flag.String("want", "", "comma-separated file names to fetch (required)")
 
@@ -38,6 +40,16 @@ func main() {
 		os.Exit(2)
 	}
 
+	// The token is read from the environment and has no flag, deliberately: a flag is
+	// visible in `ps` to every other user on the machine, and lands in any CI log that
+	// echoes the command it ran.
+	src := shelf.Source{
+		API:   *api,
+		Repo:  *repo,
+		Tag:   *tag,
+		Token: os.Getenv(shelf.TokenEnv),
+	}
+
 	// Interruptible, because this moves a couple of hundred megabytes and the first
 	// thing anybody does to a fetch that is taking too long is press ^C.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -45,7 +57,7 @@ func main() {
 
 	log := func(format string, a ...any) { fmt.Fprintf(os.Stderr, "anchor-fetch: "+format+"\n", a...) }
 
-	if err := shelf.Fetch(ctx, *url, names, *dest, log); err != nil {
+	if err := shelf.Fetch(ctx, src, names, *dest, log); err != nil {
 		fmt.Fprintf(os.Stderr, "anchor-fetch: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/build.md
+++ b/docs/build.md
@@ -22,12 +22,12 @@ refreshed. So `anchor/bin/` is ignored, and a build populates it:
 ```console
 $ make anchor-bins                              # from ../anchor
 $ make anchor-bins ANCHOR_SRC=/path/to/anchor   # from somewhere else
-$ make anchor-bins FETCH=1                      # from the shelf; no checkout needed
+$ make anchor-bins FETCH=1                      # from anchor's release; needs a token
 anchor-bins: 14/14 copied from ../anchor/release (release)
 ```
 
 The script looks for `release/` first, falls back to `dist/`, and with `FETCH=1` falls
-back again to the published shelf. Those are not
+back again to anchor's published release. Those are not
 interchangeable: `release/` is the pinned, garbled build users get, and `dist/` is the
 unpinned development cross-build, which will join **any** realm tree. A conflux built
 from `dist/` is fine for development and wrong for anything shipped, and the script
@@ -39,22 +39,46 @@ embedded into every conflux a user runs. The release workflow fails on its prese
 
 ### The shelf
 
-`make anchor-bins FETCH=1` fetches the **pinned** build from
-`https://api.veilnet.com.au/anchor/release`, with no anchor checkout and no credential:
+`make anchor-bins FETCH=1` fetches the **pinned** build from the `shelf` release of
+`veil-net/anchor`, with no anchor checkout:
 
 ```console
+$ export ANCHOR_RELEASE_TOKEN=github_pat_…
 $ make anchor-bins FETCH=1
-anchor-fetch: shelf:   https://api.veilnet.com.au/anchor/release
+anchor-fetch: shelf:   veil-net/anchor @ shelf
+anchor-fetch: commit:  0aea0f77bb77f8bbaa23c5055d9fe245d3a9bee2
 anchor-fetch: realm:   realmtglwuedqqa33e364nv73p46jk3kwi67lxjmnntz2mv3mb3mklasq
 anchor-fetch:   ok   anchord-linux-amd64           28.0 MB  95ca77b697e5
   …
 anchor-fetch: 14/14 fetched, digests verified
 ```
 
-`SHELF_URL=` points it elsewhere. The fetcher is `cmd/anchor-fetch` over
-`internal/shelf` — Go rather than curl and a JSON parser, because the promise at the top
-of this page is "Go 1.27.1 or newer, and nothing else", and a fresh clone should not have
-to acquire anything else to become buildable.
+The tag is fixed and moves: `shelf` always names anchor's newest release build, which is
+the intent — conflux ships the newest anchor, not a remembered one. Fetched by tag rather
+than by "latest", because latest is a heuristic over publication dates that a real product
+release cut in anchor would win.
+
+`ANCHOR_REPO=`, `ANCHOR_TAG=` and `ANCHOR_API=` point it elsewhere. The fetcher is
+`cmd/anchor-fetch` over `internal/shelf` — Go rather than curl and a JSON parser, because
+the promise at the top of this page is "Go 1.27.1 or newer, and nothing else", and a fresh
+clone should not have to acquire anything else to become buildable.
+
+#### The token
+
+`ANCHOR_RELEASE_TOKEN` is a GitHub token with **Contents: read** on `veil-net/anchor`. In
+CI it is the repository secret of the same name; locally, export it.
+
+It is needed because anchor is private, and GitHub has no releases-only read scope —
+releases live under Contents, the same permission that grants the source. So the token
+that reads two binaries could also clone the repository. That is the trade, made knowingly:
+
+- GitHub never passes secrets to workflows triggered by **fork** pull requests, and
+  conflux's Linux jobs refuse fork pull requests outright. The token is not reachable by
+  anyone who does not already have write access to conflux.
+- It is scoped to one repository and one permission, which is the narrowest grant GitHub
+  will cut for this.
+- Fine-grained tokens expire. When this one does, every `FETCH=1` fails with
+  `GitHub refused the token (401)`, which is the failure saying exactly what it is.
 
 What it refuses, and why each is worth a refusal:
 
@@ -62,7 +86,8 @@ What it refuses, and why each is worth a refusal:
 |---|---|
 | a digest that does not match | the failure no later gate catches — a real binary of the right size passes the size gate, and one of the right architecture passes `TestPairIsRealExecutables` |
 | `anchoradmin` on the shelf | it mints realm roots, and every file in `anchor/bin` is a candidate for being embedded into every conflux a user runs |
-| a per-binary `url` on another host | the digest catches substituted content; this catches being sent somewhere conflux was never told about |
+| `anchoradmin` attached to the release | refused on sight, before anything is downloaded — if it is being published, that is worth stopping over rather than quietly not selecting |
+| an asset still uploading | a half-finished release is not yet what its manifest claims |
 | a manifest with no `pin` | nothing then says which realm these binaries are for |
 | an unknown `formatVersion` | a future shape may mean anything, so it is refused rather than guessed at |
 | a short body, or plain http | a truncated download, and an unencrypted one |
@@ -79,8 +104,16 @@ machine with no anchor and no network run `gofmt` and the unit tests.
 
 **`FETCH=1` is opt-in for now.** The macOS and Windows CI jobs run `anchor-bins` too and
 need only the two files their own build tag names, so fetching all fourteen there would
-move 284 MB to compile 43. Once the shelf serves every target and per-target narrowing
-exists, the default is one line to flip.
+move 284 MB to compile 43. Once per-target narrowing exists, the default is one line to
+flip.
+
+**There is no URL anywhere.** An earlier version of this fetched a manifest that named a
+download URL per binary, and refused any whose host differed from the manifest's — because
+a document conflux had just downloaded was deciding where conflux would fetch from next.
+Nothing reads a URL out of a document now: every request is built from `internal/shelf`'s
+own constants, and binaries are resolved by asset **name** within one release. The set of
+places a fetch can reach is fixed by conflux's configuration rather than by anything on
+the wire, which is the stronger form of the same property.
 
 ### A clone with no anchor checkout
 
@@ -90,10 +123,9 @@ binaries still run `gofmt`, `go vet`, `staticcheck` and the unit tests, which is
 exactly what CI needs.
 
 CI is no longer in that state for the jobs that matter. `linux`, `service` and
-`integration` check anchor out beside conflux on the self-hosted runner and build
-`make dist`, so the eight tests that gate on `anchor.Supported` actually run; `cross`
-stays on placeholders deliberately, because what it asks is whether every target still
-compiles. See [testing.md](testing.md).
+`integration` fetch the pinned binaries from anchor's release, so the eight tests that
+gate on `anchor.Supported` actually run; `cross` stays on placeholders deliberately,
+because what it asks is whether every target still compiles. See [testing.md](testing.md).
 
 A placeholder build is not able to masquerade as a real one:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -265,8 +265,16 @@ stack trace a user sends back useless.
 $ make build VERSION=v0.2.0
 ```
 
-`VERSION` and `COMMIT` default to `git describe` and `git rev-parse`. An unstamped
-build says `dev`, which is the honest answer rather than a number nobody released.
+`VERSION` defaults to the contents of the `VERSION` file, and `COMMIT` to `git rev-parse`.
+A tree with no `VERSION` file says `dev`, which is the honest answer rather than a number
+nobody released.
+
+The file rather than a tag, deliberately: a tag is a claim about a commit, and the file is
+a claim about the tree — and it is the tree that gets built. It is also what decides
+whether a release happens at all. `release.yml` runs on every merge to `main`, reads this
+file, and stops immediately if a release already exists for it. So cutting a release is
+bumping `VERSION` and merging; the tag is created afterwards, at the commit that has
+already passed the whole suite, rather than being a promise made before any of it ran.
 
 ## Reproducibility
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -65,20 +65,41 @@ clone should not have to acquire anything else to become buildable.
 
 #### The token
 
-`ANCHOR_RELEASE_TOKEN` is a GitHub token with **Contents: read** on `veil-net/anchor`. In
-CI it is the repository secret of the same name; locally, export it.
+`ANCHOR_RELEASE_TOKEN` is any GitHub token with **Contents: read** on `veil-net/anchor`.
+The fetcher takes a bearer token and does not care where it came from, so locally you can
+export a personal access token and it works.
 
-It is needed because anchor is private, and GitHub has no releases-only read scope —
-releases live under Contents, the same permission that grants the source. So the token
-that reads two binaries could also clone the repository. That is the trade, made knowingly:
+**CI does not store one.** It stores the private key of a GitHub App and mints a token per
+job — see `.github/actions/anchor-bins`, which passes the result through this same
+variable. The two repository secrets are:
 
+| secret | what it is |
+|---|---|
+| `ANCHOR_APP_ID` | the App's numeric ID |
+| `ANCHOR_APP_PRIVATE_KEY` | its private key, whole, including the BEGIN and END lines |
+
+A credential is needed at all because anchor is private, and GitHub has no releases-only
+read scope — releases live under Contents, the same permission that grants the source. So
+whatever reads two binaries could also clone the repository. There is no narrower grant to
+ask for, in any credential type, and it is worth saying plainly rather than glossing.
+
+What the App changes is not what can be read but what is *kept here*:
+
+- **The stored secret is not a credential.** A personal access token in a repository secret
+  *is* the key. A private key has to be exchanged for one first, so the secret on its own
+  opens nothing.
+- **The minted token lasts an hour** and is revoked when the job ends, rather than being
+  valid until somebody notices.
+- **It does not expire and belongs to no person**, so CI does not go red a year from now
+  for a reason unrelated to any code change, and the credential does not die when somebody
+  leaves the org.
 - GitHub never passes secrets to workflows triggered by **fork** pull requests, and
-  conflux's Linux jobs refuse fork pull requests outright. The token is not reachable by
+  conflux's Linux jobs refuse fork pull requests outright, so none of this is reachable by
   anyone who does not already have write access to conflux.
-- It is scoped to one repository and one permission, which is the narrowest grant GitHub
-  will cut for this.
-- Fine-grained tokens expire. When this one does, every `FETCH=1` fails with
-  `GitHub refused the token (401)`, which is the failure saying exactly what it is.
+
+A deploy key cannot do this job. Deploy keys authenticate git transport only — `clone`,
+`fetch`, `push` over SSH — and release assets are API objects, not git objects. The REST
+API does not accept SSH keys at all.
 
 What it refuses, and why each is worth a refusal:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,10 +142,15 @@ than it wants to be and why it is nonetheless contained.
 | `docs` | veilnet-dev | two greps |
 
 A release runs all of it first. `release.yml` calls this workflow and waits on it, which
-is new: a tag push runs none of `ci.yml`'s own triggers, so before that a release was
-gated on nothing but a check that the binaries it was about to embed were real. Whether
-the code around them still worked was a convention — the tag is cut from a commit that
-was green on main — and a convention is not a check.
+is new: a release used to be gated on nothing but a check that the binaries it was about
+to embed were real. Whether the code around them still worked was a convention — the tag
+is cut from a commit that was green on main — and a convention is not a check.
+
+It runs on a **merge to `main`**, not on a tag. A `gate` job reads the `VERSION` file and
+stops the run immediately unless that version has no release yet, so most merges cost one
+cheap job rather than an hour. Two things that were previously possible are now not: a
+release built from a commit nobody had tested, and a `workflow_dispatch` on a feature
+branch publishing `make dist VERSION=<branch-name>` to the public.
 
 It also fetches those binaries now, which is what made a release from CI possible at all.
 `anchor/bin` is not in git, so a release runner had no source for it and the workflow

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,8 +126,9 @@ Every Linux job that needs Docker is on **veilnet-dev**, a self-hosted runner. W
 makes the two container suites possible, though, is not the machine — it is that
 `anchor/bin` finally has a source CI can reach. `make anchor-bins FETCH=1` fetches the
 **pinned** release build from the `shelf` release of `veil-net/anchor` and verifies every
-digest, with no anchor checkout. It needs `ANCHOR_RELEASE_TOKEN`, a repository secret
-carrying Contents: read on anchor — see [build.md](build.md) for why that grant is wider
+digest, with no anchor checkout. It needs a credential, since anchor is private: CI stores
+a GitHub App's ID and private key and mints an hour-long token per job, so the secret held
+here is not itself a key to anything — see [build.md](build.md) for why the grant is wider
 than it wants to be and why it is nonetheless contained.
 
 | job | machine | what it adds |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,8 +125,10 @@ never who is let in. Loopback is not probed, so two anchors on one machine still
 Every Linux job that needs Docker is on **veilnet-dev**, a self-hosted runner. What
 makes the two container suites possible, though, is not the machine — it is that
 `anchor/bin` finally has a source CI can reach. `make anchor-bins FETCH=1` fetches the
-**pinned** release build from the shelf and verifies every digest, with no anchor
-checkout and no credential. See [build.md](build.md).
+**pinned** release build from the `shelf` release of `veil-net/anchor` and verifies every
+digest, with no anchor checkout. It needs `ANCHOR_RELEASE_TOKEN`, a repository secret
+carrying Contents: read on anchor — see [build.md](build.md) for why that grant is wider
+than it wants to be and why it is nonetheless contained.
 
 | job | machine | what it adds |
 |---|---|---|
@@ -146,12 +148,17 @@ was green on main — and a convention is not a check.
 
 It also fetches those binaries now, which is what made a release from CI possible at all.
 `anchor/bin` is not in git, so a release runner had no source for it and the workflow
-failed on its own error message saying so. Both release jobs fetch from the shelf, and
-neither pins anything: a release carries whatever anchor published most recently, which
-is the intent — conflux ships the newest anchor, not a remembered one. All seven targets
-are cross-built from the one Linux machine, `CGO_ENABLED=0` throughout.
+failed on its own error message saying so. Both release jobs fetch the `shelf` release,
+and neither pins a version of it: the tag moves, so a conflux release carries whatever
+anchor published most recently, which is the intent — conflux ships the newest anchor,
+not a remembered one. All seven targets are cross-built from the one Linux machine,
+`CGO_ENABLED=0` throughout.
 
-**The binaries CI uses are the pinned ones.** That is what the shelf serves, and it is
+`release.yml` calls `ci.yml` with `secrets: inherit`. Without that the called workflow
+gets no secrets at all — they are not inherited by default — and every `anchor-bins` step
+inside it would fail on a token that is set in one file and empty in the other.
+
+**The binaries CI uses are the pinned ones.** That is what the release serves, and it is
 the property a locally-built `make dist` cannot have: an anchor pinned to the genesis
 realm refuses to handshake with any other tree. So `integration` now exercises the
 binaries that actually ship, rather than a development cross-build that would join

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,11 +146,21 @@ is new: a release used to be gated on nothing but a check that the binaries it w
 to embed were real. Whether the code around them still worked was a convention — the tag
 is cut from a commit that was green on main — and a convention is not a check.
 
-It runs on a **merge to `main`**, not on a tag. A `gate` job reads the `VERSION` file and
-stops the run immediately unless that version has no release yet, so most merges cost one
-cheap job rather than an hour. Two things that were previously possible are now not: a
-release built from a commit nobody had tested, and a `workflow_dispatch` on a feature
-branch publishing `make dist VERSION=<branch-name>` to the public.
+It runs on a **merge to `main`**, not on a tag — and `ci.yml` no longer triggers on `main`
+at all, so the suite runs once per merge rather than twice. A `gate` job reads the
+`VERSION` file; the tests run either way, and only `verify` and `build` are skipped when
+that version already has a release. So an ordinary merge costs the suite, and a release
+merge costs the suite plus seven cross-builds.
+
+Two things that were previously possible are now not: a release built from a commit nobody
+had tested, and a `workflow_dispatch` on a feature branch publishing
+`make dist VERSION=<branch-name>` to the public.
+
+The PR run and the merge run are both wanted, and they are not the same thing. GitHub
+tests `refs/pull/N/merge` — the branch already merged into its base — so as a *test* the
+second is redundant whenever the base has not moved. But the merge run is the release
+build: it produces the seven binaries and publishes them, and artifacts cannot come from a
+run of a different commit.
 
 It also fetches those binaries now, which is what made a release from CI possible at all.
 `anchor/bin` is not in git, so a release runner had no source for it and the workflow

--- a/internal/shelf/shelf.go
+++ b/internal/shelf/shelf.go
@@ -1,19 +1,36 @@
-// Package shelf fetches the anchor binaries from the published release manifest.
+// Package shelf fetches the anchor binaries from a release of the anchor repository.
 //
-// The binaries are not in git -- fourteen release builds are about 284 MB -- and until
-// now the only way to get them was a local anchor checkout, which is why CI ran on
-// placeholders and eight tests skipped on every machine but a developer's.
+// The binaries are not in git -- fourteen release builds are about 284 MB -- and without
+// a source for them CI ran on placeholders and eight tests skipped on every machine but
+// a developer's.
 //
-// The shelf is the answer that needs no credential. What it serves is what conflux
-// already ships: `//go:embed` puts these bytes inside every published conflux, so a
-// public shelf discloses nothing a release download does not. That is the whole reason
-// this can be an unauthenticated GET rather than a token for a private repository --
-// conflux needs anchor's *output*, and its output is not the secret. anchor's source
-// stays where it is.
+// What is fetched is the *pinned* build. An anchor pinned to the genesis realm refuses to
+// handshake with any other tree, which is the property worth having and the one a local
+// `make dist` cannot give.
 //
-// What is fetched is the *pinned* build. An anchor pinned to the genesis realm refuses
-// to handshake with any other tree, which is the property worth having and the one a
-// local `make dist` cannot give.
+// # Why this needs a credential
+//
+// anchor is a private repository, and GitHub has no releases-only read scope: releases
+// live under Contents, the same permission that grants the source. So the token conflux
+// holds to read two binaries could also clone the repository, and that is the trade being
+// made knowingly rather than by accident.
+//
+// It is acceptable for a reason worth stating rather than re-deriving: GitHub never passes
+// secrets to workflows triggered by fork pull requests, and conflux's Linux jobs refuse
+// fork pull requests outright, so the token is not reachable by anyone who does not
+// already have write access to conflux.
+//
+// # What replaced the same-host rule
+//
+// An earlier version of this fetched a manifest that named a download URL per binary, and
+// refused any URL whose host differed from the manifest's. That rule existed because a
+// document conflux had just downloaded was deciding where conflux would fetch from next.
+//
+// Nothing here reads a URL out of a document. Every request is built from this package's
+// own constants -- one API host, one repository, one tag -- and binaries are resolved by
+// *asset name* within that single release. The set of places a fetch can reach is fixed by
+// conflux's configuration rather than by anything on the wire, which is the stronger form
+// of the same property.
 package shelf
 
 import (
@@ -34,31 +51,72 @@ import (
 )
 
 const (
-	// DefaultURL is where the manifest lives. Overridable so a dev shelf can be
-	// pointed at, and deliberately not a value any *runtime* path reads: this is a
-	// build-time source for bytes, not a thing a running conflux ever contacts.
-	DefaultURL = "https://api.veilnet.com.au/anchor/release"
+	// DefaultAPI, DefaultRepo and DefaultTag are the whole of the contract with anchor.
+	// The tag moves: it always names anchor's newest release build, which is the intent
+	// -- conflux ships the newest anchor, not a remembered one.
+	DefaultAPI  = "https://api.github.com"
+	DefaultRepo = "veil-net/anchor"
+	DefaultTag  = "shelf"
 
-	// insecureEnv permits a plain-http shelf, for a test server. Named to match
+	// TokenEnv carries the credential. An environment variable and never a flag: a flag
+	// is visible in `ps` to every other user on the machine, and lands in any CI log
+	// that echoes the command it ran.
+	TokenEnv = "ANCHOR_RELEASE_TOKEN"
+
+	// manifestName is the asset that describes the others. Fetched first, and the only
+	// asset whose name is known ahead of time.
+	manifestName = "manifest.json"
+
+	// insecureEnv permits a plain-http API, for a test server. Named to match
 	// internal/enrol's own override rather than inventing a second spelling.
 	insecureEnv = "CONFLUX_ALLOW_INSECURE_API"
 
-	// formatVersion is the manifest shape this understands. A future version may
-	// mean anything, so an unknown one is refused rather than guessed at -- the same
-	// rule internal/enrol applies to a manifest it does not recognise.
+	// formatVersion is the manifest shape this understands. A future version may mean
+	// anything, so an unknown one is refused rather than guessed at -- the same rule
+	// internal/enrol applies to a manifest it does not recognise.
 	formatVersion = 1
 
-	// maxManifest bounds the JSON; maxBinary bounds one download. An anchord is
-	// about 30 MB and anchorctl about 14, so 200 MB is far above anything real and
-	// far below anything that could fill a disk before the write fails.
+	// maxManifest bounds the JSON; maxBinary bounds one download. An anchord is about
+	// 30 MB and anchorctl about 14, so 200 MB is far above anything real and far below
+	// anything that could fill a disk before the write fails.
 	maxManifest = 1 << 20
 	maxBinary   = 200 << 20
 
-	manifestTimeout = 30 * time.Second
-	binaryTimeout   = 10 * time.Minute
+	releaseTimeout = 30 * time.Second
+	binaryTimeout  = 10 * time.Minute
 )
 
+// Source is where the binaries come from. Zero fields take the defaults above, except
+// Token, which has none.
+type Source struct {
+	API   string
+	Repo  string
+	Tag   string
+	Token string
+}
+
+func (s Source) withDefaults() Source {
+	if s.API == "" {
+		s.API = DefaultAPI
+	}
+
+	if s.Repo == "" {
+		s.Repo = DefaultRepo
+	}
+
+	if s.Tag == "" {
+		s.Tag = DefaultTag
+	}
+
+	s.API = strings.TrimSuffix(s.API, "/")
+
+	return s
+}
+
 // Binary is one entry in the manifest.
+//
+// No URL. The name is what locates the file, as an asset of the release being read --
+// see the package comment on what that replaced and why it is the stronger rule.
 type Binary struct {
 	Name    string `json:"name"`
 	Program string `json:"program"`
@@ -66,28 +124,75 @@ type Binary struct {
 	Arch    string `json:"arch"`
 	Bytes   int64  `json:"bytes"`
 	SHA256  string `json:"sha256"`
-	URL     string `json:"url"`
 }
 
-// Manifest is what the shelf serves.
+// Manifest is the asset that describes the rest of them.
 type Manifest struct {
 	FormatVersion int      `json:"formatVersion"`
 	Pin           string   `json:"pin"`
 	Binaries      []Binary `json:"binaries"`
 }
 
-// Fetch downloads every binary named by want into dir, verifying each against the
-// digest the manifest gives for it.
+type asset struct {
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Size  int64  `json:"size"`
+	State string `json:"state"`
+}
+
+type release struct {
+	ID              int64   `json:"id"`
+	TagName         string  `json:"tag_name"`
+	TargetCommitish string  `json:"target_commitish"`
+	Assets          []asset `json:"assets"`
+}
+
+// Fetch downloads every binary named by want into dir, verifying each against the digest
+// the manifest gives for it.
 //
 // want is the set of file names conflux embeds -- "anchord-linux-amd64" and the other
-// thirteen. It is passed in rather than derived here so that the list of targets stays
-// in one place, scripts/anchor-bins.sh, which is also what prunes the directory.
-func Fetch(ctx context.Context, base string, want []string, dir string, log func(string, ...any)) error {
-	if err := checkScheme(base); err != nil {
+// thirteen. It is passed in rather than derived here so that the list of targets stays in
+// one place, scripts/anchor-bins.sh, which is also what prunes the directory.
+func Fetch(ctx context.Context, src Source, want []string, dir string, log func(string, ...any)) error {
+	src = src.withDefaults()
+
+	if err := checkScheme(src.API); err != nil {
 		return err
 	}
 
-	m, err := manifest(ctx, base)
+	if src.Token == "" {
+		return fmt.Errorf("no token: set %s to a GitHub token with Contents: read on %s", TokenEnv, src.Repo)
+	}
+
+	if !strings.Contains(strings.Trim(src.Repo, "/"), "/") {
+		return fmt.Errorf("%q is not an owner/name repository", src.Repo)
+	}
+
+	rel, err := lookup(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	assets := map[string]asset{}
+
+	for _, a := range rel.Assets {
+		// anchoradmin can mint realm roots. It has no business on the shelf and
+		// certainly none in anchor/bin, every file of which is a candidate for being
+		// embedded into every conflux a user runs. Refused on sight of it in the
+		// release, before anything is downloaded -- if it is being published, that is
+		// worth stopping over rather than quietly not selecting.
+		if strings.HasPrefix(a.Name, "anchoradmin") {
+			return fmt.Errorf("the release carries %q, which mints realm roots and must never be published", a.Name)
+		}
+
+		if a.State != "" && a.State != "uploaded" {
+			return fmt.Errorf("the asset %q is in state %q, so the release is not finished", a.Name, a.State)
+		}
+
+		assets[a.Name] = a
+	}
+
+	m, err := manifest(ctx, src, assets)
 	if err != nil {
 		return err
 	}
@@ -104,25 +209,29 @@ func Fetch(ctx context.Context, base string, want []string, dir string, log func
 	byName := map[string]Binary{}
 
 	for _, b := range m.Binaries {
-		// anchoradmin can mint realm roots. It has no business on a public shelf and
-		// certainly none in anchor/bin, every file of which is a candidate for being
-		// embedded into every conflux a user runs. Refused here rather than deleted
-		// after the fact: if it is being served, that is worth stopping over.
 		if b.Program == "anchoradmin" || strings.HasPrefix(b.Name, "anchoradmin") {
-			return fmt.Errorf("the shelf is serving %q, which mints realm roots and must never be published", b.Name)
+			return fmt.Errorf("the manifest describes %q, which mints realm roots and must never be published", b.Name)
 		}
 
 		byName[b.Name] = b
 	}
 
-	log("shelf:   %s", base)
+	log("shelf:   %s @ %s", src.Repo, src.Tag)
+	log("commit:  %s", rel.TargetCommitish)
 	log("realm:   %s", m.Pin)
 
 	var missing []string
 
+	// Both, because they are different failures with the same remedy: a binary the
+	// manifest never described, and one it described that was not attached.
 	for _, name := range want {
 		if _, ok := byName[name]; !ok {
-			missing = append(missing, name)
+			missing = append(missing, name+" (not in the manifest)")
+			continue
+		}
+
+		if _, ok := assets[name]; !ok {
+			missing = append(missing, name+" (in the manifest, not attached to the release)")
 		}
 	}
 
@@ -136,7 +245,7 @@ func Fetch(ctx context.Context, base string, want []string, dir string, log func
 	for _, name := range want {
 		b := byName[name]
 
-		if err := download(ctx, base, b, filepath.Join(dir, name)); err != nil {
+		if err := download(ctx, src, assets[name], b, filepath.Join(dir, name)); err != nil {
 			return fmt.Errorf("%s: %w", name, err)
 		}
 
@@ -146,23 +255,60 @@ func Fetch(ctx context.Context, base string, want []string, dir string, log func
 	return nil
 }
 
-func manifest(ctx context.Context, base string) (*Manifest, error) {
-	ctx, cancel := context.WithTimeout(ctx, manifestTimeout)
+// lookup reads the release at the configured tag.
+//
+// By tag rather than by "latest": latest is a heuristic over publication dates that a
+// real product release cut in anchor would win, and conflux would then embed something
+// that was never meant for it. A tag is exact.
+func lookup(ctx context.Context, src Source) (*release, error) {
+	ctx, cancel := context.WithTimeout(ctx, releaseTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base, nil)
-	if err != nil {
-		return nil, err
-	}
+	u := fmt.Sprintf("%s/repos/%s/releases/tags/%s", src.API, strings.Trim(src.Repo, "/"), url.PathEscape(src.Tag))
 
-	resp, err := client(base).Do(req)
+	resp, err := do(ctx, src, u, "application/vnd.github+json")
 	if err != nil {
-		return nil, fmt.Errorf("fetching the manifest: %w", err)
+		return nil, fmt.Errorf("looking up the release: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("the shelf answered %s", resp.Status)
+	if err := statusErr(resp, src); err != nil {
+		return nil, err
+	}
+
+	var rel release
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxManifest)).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("the release is not the JSON this expects: %w", err)
+	}
+
+	return &rel, nil
+}
+
+func manifest(ctx context.Context, src Source, assets map[string]asset) (*Manifest, error) {
+	a, ok := assets[manifestName]
+	if !ok {
+		names := make([]string, 0, len(assets))
+		for n := range assets {
+			names = append(names, n)
+		}
+
+		sort.Strings(names)
+
+		return nil, fmt.Errorf("the release at %s has no %s, so nothing describes its %d asset(s): %s",
+			src.Tag, manifestName, len(names), strings.Join(names, ", "))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, releaseTimeout)
+	defer cancel()
+
+	resp, err := do(ctx, src, assetURL(src, a), "application/octet-stream")
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", manifestName, err)
+	}
+	defer resp.Body.Close()
+
+	if err := statusErr(resp, src); err != nil {
+		return nil, err
 	}
 
 	var m Manifest
@@ -179,27 +325,18 @@ func manifest(ctx context.Context, base string) (*Manifest, error) {
 // leave a half-written file that is a real binary of nearly the right size -- which is
 // exactly the shape neither the size gate in `make dist` nor the header check in
 // anchor.TestPairIsRealExecutables would catch.
-func download(ctx context.Context, base string, b Binary, dest string) error {
-	if err := sameHost(base, b.URL); err != nil {
-		return err
-	}
-
+func download(ctx context.Context, src Source, a asset, b Binary, dest string) error {
 	ctx, cancel := context.WithTimeout(ctx, binaryTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, b.URL, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client(base).Do(req)
+	resp, err := do(ctx, src, assetURL(src, a), "application/octet-stream")
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("the shelf answered %s", resp.Status)
+	if err := statusErr(resp, src); err != nil {
+		return err
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(dest), ".anchor-fetch-*")
@@ -238,17 +375,69 @@ func download(ctx context.Context, base string, b Binary, dest string) error {
 	return os.Rename(tmp.Name(), dest)
 }
 
-func client(base string) *http.Client {
-	u, _ := url.Parse(base)
+func assetURL(src Source, a asset) string {
+	return fmt.Sprintf("%s/repos/%s/releases/assets/%d", src.API, strings.Trim(src.Repo, "/"), a.ID)
+}
 
+func do(ctx context.Context, src Source, u, accept string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+src.Token)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	return client().Do(req)
+}
+
+// statusErr turns the codes this actually meets into the sentence somebody can act on.
+// A bare "404 Not Found" against a private repository is the least informative true
+// statement available: it is what GitHub returns both for a tag that does not exist and
+// for a token that cannot see the repository at all.
+func statusErr(resp *http.Response, src Source) error {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+
+	case http.StatusUnauthorized:
+		return fmt.Errorf("GitHub refused the token (401). %s is set but not valid -- most often expired", TokenEnv)
+
+	case http.StatusForbidden:
+		if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			return errors.New("GitHub rate limit reached (403)")
+		}
+
+		return fmt.Errorf("GitHub refused the token (403). %s needs Contents: read on %s", TokenEnv, src.Repo)
+
+	case http.StatusNotFound:
+		return fmt.Errorf(
+			"no release tagged %q in %s (404) -- or the token cannot see that repository at all, which GitHub reports the same way.\n"+
+				"  Check: anchor's ci.yml has published the %q tag, and %s grants Contents: read on %s",
+			src.Tag, src.Repo, src.Tag, TokenEnv, src.Repo)
+
+	default:
+		return fmt.Errorf("GitHub answered %s", resp.Status)
+	}
+}
+
+func client() *http.Client {
 	return &http.Client{
-		// A download that follows a redirect to another host is one this did not
-		// agree to. The digest would still have to match, so this is belt and
-		// braces -- and cheap enough to keep, because the alternative is trusting
-		// that the digest check is never the only thing standing up.
+		// An asset download answers with a redirect to storage on another host, so
+		// unlike the manifest-and-URL scheme this replaced, a cross-host hop is
+		// expected and cannot be refused outright.
+		//
+		// Two things make that safe. Go drops the Authorization header on a redirect
+		// to a different host, so the token never reaches the storage host. And the
+		// digest is checked against a manifest fetched from the API, so content
+		// substituted anywhere along the way fails the compare.
+		//
+		// What is still refused is a downgrade: a redirect to plain http, which would
+		// hand the bytes to anyone on the path.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if u != nil && req.URL.Host != u.Host {
-				return fmt.Errorf("refusing a redirect from %s to %s", u.Host, req.URL.Host)
+			if err := checkScheme(req.URL.String()); err != nil {
+				return err
 			}
 
 			if len(via) >= 5 {
@@ -258,30 +447,6 @@ func client(base string) *http.Client {
 			return nil
 		},
 	}
-}
-
-// sameHost refuses a per-binary url that points somewhere other than the manifest.
-//
-// The manifest names its own download URLs, so a compromised or mistaken shelf could
-// point them at a third party. The digest would catch substituted *content*; this
-// catches conflux being made to fetch from somewhere it was never told about, which is
-// worth refusing on its own.
-func sameHost(base, raw string) error {
-	b, err := url.Parse(base)
-	if err != nil {
-		return err
-	}
-
-	t, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("%q is not a URL: %w", raw, err)
-	}
-
-	if t.Host != b.Host {
-		return fmt.Errorf("the manifest points at %s, which is not the shelf at %s", t.Host, b.Host)
-	}
-
-	return checkScheme(raw)
 }
 
 func checkScheme(raw string) error {

--- a/internal/shelf/shelf_test.go
+++ b/internal/shelf/shelf_test.go
@@ -15,264 +15,509 @@ import (
 	"testing"
 )
 
-// serve stands up a shelf holding the given files, and returns its base URL.
+// A release, served the way GitHub serves one: a release document listing assets by id,
+// and an asset endpoint per id that answers with the bytes.
 //
-// The manifest's own urls point back at this server, which is what makes the same-host
-// rule testable: a test that wants to break it rewrites them afterwards.
-func serve(t *testing.T, files map[string][]byte, edit func(*Manifest)) string {
+// Modelled on the real API rather than on what this package happens to need, because the
+// gap between those two is where a fetcher that passes its tests and fails in CI lives.
+type fakeRelease struct {
+	tag    string
+	commit string
+	files  map[string][]byte
+
+	// states overrides an asset's state, for the half-finished-release case.
+	states map[string]string
+
+	// manifestJSON overrides the generated manifest, for the malformed cases.
+	manifestJSON string
+
+	requests []string
+	tokens   []string
+}
+
+func newRelease(files map[string][]byte) *fakeRelease {
+	return &fakeRelease{
+		tag:    "shelf",
+		commit: "0aea0f77bb77f8bbaa23c5055d9fe245d3a9bee2",
+		files:  files,
+		states: map[string]string{},
+	}
+}
+
+func (f *fakeRelease) manifest(pin string, version int) string {
+	if f.manifestJSON != "" {
+		return f.manifestJSON
+	}
+
+	type entry struct {
+		Name    string `json:"name"`
+		Program string `json:"program"`
+		OS      string `json:"os"`
+		Arch    string `json:"arch"`
+		Bytes   int64  `json:"bytes"`
+		SHA256  string `json:"sha256"`
+	}
+
+	var entries []entry
+
+	for name, body := range f.files {
+		sum := sha256.Sum256(body)
+		entries = append(entries, entry{
+			Name:    name,
+			Program: strings.SplitN(name, "-", 2)[0],
+			OS:      "linux",
+			Arch:    "amd64",
+			Bytes:   int64(len(body)),
+			SHA256:  hex.EncodeToString(sum[:]),
+		})
+	}
+
+	out, _ := json.Marshal(map[string]any{
+		"formatVersion": version,
+		"pin":           pin,
+		"binaries":      entries,
+	})
+
+	return string(out)
+}
+
+// serve returns a server and the Source pointing at it. The manifest is built from files
+// unless one was set explicitly.
+func (f *fakeRelease) serve(t *testing.T, pin string, version int) (*httptest.Server, Source) {
 	t.Helper()
 
+	// ids are assigned in one pass so that the release document and the asset endpoints
+	// agree without either being the source of truth for the other.
+	ids := map[string]int64{}
+	byID := map[int64]string{}
+
+	var id int64 = 100
+
+	names := []string{manifestName}
+	for name := range f.files {
+		names = append(names, name)
+	}
+
+	for _, name := range names {
+		ids[name] = id
+		byID[id] = name
+		id++
+	}
+
+	bodies := func(name string) []byte {
+		if name == manifestName {
+			return []byte(f.manifest(pin, version))
+		}
+
+		return f.files[name]
+	}
+
 	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/veil-net/anchor/releases/tags/", func(w http.ResponseWriter, r *http.Request) {
+		f.requests = append(f.requests, r.URL.Path)
+		f.tokens = append(f.tokens, r.Header.Get("Authorization"))
+
+		tag := strings.TrimPrefix(r.URL.Path, "/repos/veil-net/anchor/releases/tags/")
+		if tag != f.tag {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"Not Found"}`)
+
+			return
+		}
+
+		type a struct {
+			ID    int64  `json:"id"`
+			Name  string `json:"name"`
+			Size  int64  `json:"size"`
+			State string `json:"state"`
+		}
+
+		var assets []a
+
+		for _, name := range names {
+			state := "uploaded"
+			if s, ok := f.states[name]; ok {
+				state = s
+			}
+
+			assets = append(assets, a{ID: ids[name], Name: name, Size: int64(len(bodies(name))), State: state})
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":               42,
+			"tag_name":         f.tag,
+			"target_commitish": f.commit,
+			"assets":           assets,
+		})
+	})
+
+	mux.HandleFunc("/repos/veil-net/anchor/releases/assets/", func(w http.ResponseWriter, r *http.Request) {
+		f.requests = append(f.requests, r.URL.Path)
+		f.tokens = append(f.tokens, r.Header.Get("Authorization"))
+
+		var got int64
+		fmt.Sscanf(strings.TrimPrefix(r.URL.Path, "/repos/veil-net/anchor/releases/assets/"), "%d", &got)
+
+		name, ok := byID[got]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		_, _ = w.Write(bodies(name))
+	})
+
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	m := Manifest{FormatVersion: 1, Pin: "realmtestpin"}
-
-	for name, body := range files {
-		sum := sha256.Sum256(body)
-		m.Binaries = append(m.Binaries, Binary{
-			Name:   name,
-			Bytes:  int64(len(body)),
-			SHA256: hex.EncodeToString(sum[:]),
-			URL:    srv.URL + "/" + name,
-		})
-
-		mux.HandleFunc("/"+name, func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write(body)
-		})
-	}
-
-	if edit != nil {
-		edit(&m)
-	}
-
-	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(m)
-	})
-
-	// The test server is plain http, which Fetch refuses by design. Same override
-	// internal/enrol's client uses, and set through t.Setenv so it cannot leak.
 	t.Setenv(insecureEnv, "1")
 
-	return srv.URL
+	return srv, Source{API: srv.URL, Repo: "veil-net/anchor", Tag: "shelf", Token: "t0ken"}
 }
 
 func quiet(string, ...any) {}
 
-func TestFetchWritesVerifiedBinaries(t *testing.T) {
-	files := map[string][]byte{
-		"anchord-linux-amd64":   []byte("an anchord, for the purposes of this test"),
-		"anchorctl-linux-amd64": []byte("an anchorctl"),
+const testPin = "realmtglwuedqqa33e364nv73p46jk3kwi67lxjmnntz2mv3mb3mklasq"
+
+func pair() map[string][]byte {
+	return map[string][]byte{
+		"anchord-linux-amd64":   []byte(strings.Repeat("d", 4096)),
+		"anchorctl-linux-amd64": []byte(strings.Repeat("c", 2048)),
 	}
+}
+
+func TestFetchWritesVerifiedBinaries(t *testing.T) {
+	files := pair()
+	f := newRelease(files)
+	_, src := f.serve(t, testPin, 1)
 
 	dir := t.TempDir()
-	base := serve(t, files, nil)
 
-	if err := Fetch(context.Background(), base, keys(files), dir, quiet); err != nil {
+	want := []string{"anchord-linux-amd64", "anchorctl-linux-amd64"}
+	if err := Fetch(context.Background(), src, want, dir, quiet); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 
-	for name, want := range files {
+	for _, name := range want {
 		got, err := os.ReadFile(filepath.Join(dir, name))
 		if err != nil {
-			t.Fatalf("%s: %v", name, err)
+			t.Fatalf("reading %s: %v", name, err)
 		}
 
-		if string(got) != string(want) {
-			t.Errorf("%s: content is %q, want %q", name, got, want)
+		if string(got) != string(files[name]) {
+			t.Errorf("%s: wrong bytes", name)
 		}
 
-		// Executable, because the whole point is that libexec extracts and runs it.
-		//
 		// Not on Windows: Go maps a file mode to the read-only attribute there, so
-		// Perm() never reports an executable bit and this would fail on every run for
-		// a reason that has nothing to do with the fetch. internal/config's atomic
-		// tests skip for the same reason and say the same thing -- mode bits are not
-		// meaningful on windows, the DACL is.
+		// Perm() never reports an executable bit whatever was asked for.
 		if runtime.GOOS == "windows" {
 			continue
 		}
 
-		info, err := os.Stat(filepath.Join(dir, name))
+		fi, err := os.Stat(filepath.Join(dir, name))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if info.Mode().Perm()&0o111 == 0 {
-			t.Errorf("%s: mode is %v, which is not executable", name, info.Mode().Perm())
+		if fi.Mode().Perm()&0o111 == 0 {
+			t.Errorf("%s is not executable: %v", name, fi.Mode().Perm())
 		}
 	}
 }
 
-// TestFetchRefusesAWrongDigest is the assertion the whole package exists for. A shelf
-// that serves the wrong bytes for a name is the failure no later gate catches: a real
-// binary of the right size passes the size gate in `make dist`, and one of the right
-// architecture passes anchor.TestPairIsRealExecutables.
-func TestFetchRefusesAWrongDigest(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("the right bytes")}
+// The token must reach the API and it must be a Bearer. A fetch that silently sent no
+// credential would pass every other test here against a server that does not check one,
+// and fail only against the private repository it exists for.
+func TestFetchSendsTheToken(t *testing.T) {
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 1)
 
-	base := serve(t, files, func(m *Manifest) {
-		m.Binaries[0].SHA256 = strings.Repeat("00", sha256.Size)
-		m.Binaries[0].Bytes = 0 // so the length check does not fire first
-	})
-
-	dir := t.TempDir()
-
-	err := Fetch(context.Background(), base, keys(files), dir, quiet)
-	if err == nil {
-		t.Fatal("a digest that does not match should be refused")
+	if err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet); err != nil {
+		t.Fatalf("Fetch: %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "sha256") {
-		t.Errorf("the error should name the digest; it said: %v", err)
+	if len(f.tokens) == 0 {
+		t.Fatal("no requests were made")
 	}
 
-	// And nothing is left behind: a rejected download must not be renamed into place,
-	// or the next build embeds it.
-	if entries, _ := os.ReadDir(dir); len(entries) != 0 {
-		t.Errorf("a refused download left %d files in place", len(entries))
+	for i, got := range f.tokens {
+		if got != "Bearer t0ken" {
+			t.Errorf("request %d (%s) carried Authorization %q", i, f.requests[i], got)
+		}
 	}
 }
 
-// TestFetchRefusesAnchoradmin: it mints realm roots, and anything in anchor/bin is a
-// candidate for being embedded into every conflux a user runs. Refused rather than
-// filtered, because a shelf serving it at all is worth stopping over.
-func TestFetchRefusesAnchoradmin(t *testing.T) {
-	files := map[string][]byte{
-		"anchord-linux-amd64":     []byte("fine"),
-		"anchoradmin-linux-amd64": []byte("not fine"),
+func TestFetchRefusesAWrongDigest(t *testing.T) {
+	files := pair()
+	f := newRelease(files)
+
+	// A manifest describing different bytes from the ones served: the substitution the
+	// digest exists to catch.
+	f.manifestJSON = f.manifest(testPin, 1)
+	f.manifestJSON = strings.Replace(f.manifestJSON,
+		hex.EncodeToString(sha256Of(files["anchord-linux-amd64"])),
+		strings.Repeat("a", 64), 1)
+
+	_, src := f.serve(t, testPin, 1)
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "sha256") {
+		t.Fatalf("want a digest refusal, got %v", err)
+	}
+}
+
+// A failed fetch must leave nothing behind. The temp-and-rename exists so a half-written
+// file cannot be mistaken for a binary, and this is what proves it.
+func TestARefusedFetchWritesNothing(t *testing.T) {
+	files := pair()
+	f := newRelease(files)
+	f.manifestJSON = strings.Replace(f.manifest(testPin, 1),
+		hex.EncodeToString(sha256Of(files["anchord-linux-amd64"])),
+		strings.Repeat("a", 64), 1)
+
+	_, src := f.serve(t, testPin, 1)
+
+	dir := t.TempDir()
+
+	if err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, dir, quiet); err == nil {
+		t.Fatal("want a refusal")
 	}
 
-	base := serve(t, files, nil)
-
-	err := Fetch(context.Background(), base, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
-	if err == nil {
-		t.Fatal("a shelf serving anchoradmin should be refused")
+	left, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if !strings.Contains(err.Error(), "anchoradmin") {
-		t.Errorf("the error should name it; it said: %v", err)
+	if len(left) != 0 {
+		names := []string{}
+		for _, e := range left {
+			names = append(names, e.Name())
+		}
+
+		t.Fatalf("a refused fetch left %v behind", names)
+	}
+}
+
+// anchoradmin mints realm roots. Refused on sight in the release, before anything is
+// downloaded -- not merely left unselected.
+func TestFetchRefusesAnchoradminInTheRelease(t *testing.T) {
+	files := pair()
+	files["anchoradmin-linux-amd64"] = []byte("admin")
+
+	f := newRelease(files)
+	_, src := f.serve(t, testPin, 1)
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "anchoradmin") {
+		t.Fatalf("want an anchoradmin refusal, got %v", err)
 	}
 }
 
 func TestFetchNamesWhatIsMissing(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("only one of them")}
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 1)
 
-	base := serve(t, files, nil)
+	want := []string{"anchord-linux-amd64", "anchord-darwin-arm64", "anchorctl-darwin-arm64"}
 
-	err := Fetch(context.Background(), base,
-		[]string{"anchord-linux-amd64", "anchorctl-linux-amd64", "anchord-darwin-arm64"},
-		t.TempDir(), quiet)
+	err := Fetch(context.Background(), src, want, t.TempDir(), quiet)
 	if err == nil {
-		t.Fatal("a partial shelf should be refused")
+		t.Fatal("want a missing-binaries refusal")
 	}
 
-	// Both of them, by name. This is the state the real shelf is in today, so the
-	// message is the thing somebody acts on.
-	for _, want := range []string{"anchorctl-linux-amd64", "anchord-darwin-arm64"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("the error should name %s; it said: %v", want, err)
+	for _, name := range []string{"anchord-darwin-arm64", "anchorctl-darwin-arm64"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("the error does not name %s: %v", name, err)
 		}
 	}
 }
 
+// A binary the manifest describes but that was never attached. Distinct from "not in the
+// manifest", and the message says which -- they have different causes in anchor's
+// publish step.
+func TestFetchNamesAnUnattachedBinary(t *testing.T) {
+	files := pair()
+	f := newRelease(files)
+
+	// Describe a third binary in the manifest without serving it.
+	f.manifestJSON = strings.Replace(f.manifest(testPin, 1), `"binaries":[`,
+		`"binaries":[{"name":"anchord-darwin-arm64","program":"anchord","os":"darwin","arch":"arm64","bytes":1,"sha256":"`+
+			strings.Repeat("b", 64)+`"},`, 1)
+
+	_, src := f.serve(t, testPin, 1)
+
+	err := Fetch(context.Background(), src, []string{"anchord-darwin-arm64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "not attached to the release") {
+		t.Fatalf("want an unattached refusal, got %v", err)
+	}
+}
+
 func TestFetchRefusesAnUnknownFormatVersion(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 2)
 
-	base := serve(t, files, func(m *Manifest) { m.FormatVersion = 2 })
-
-	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
-	if err == nil {
-		t.Fatal("a future manifest format should be refused rather than guessed at")
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "format") {
+		t.Fatalf("want a format refusal, got %v", err)
 	}
 }
 
 func TestFetchRefusesAManifestWithNoPin(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+	f := newRelease(pair())
+	_, src := f.serve(t, "", 1)
 
-	base := serve(t, files, func(m *Manifest) { m.Pin = "" })
-
-	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
-	if err == nil {
-		t.Fatal("a manifest with no pin says nothing about which realm these are for")
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "pin") {
+		t.Fatalf("want a pin refusal, got %v", err)
 	}
 }
 
-// TestFetchRefusesAForeignURL: the manifest names its own download urls, so a shelf
-// could point them at a third party. The digest would catch substituted content; this
-// catches being sent somewhere conflux was never told about.
-func TestFetchRefusesAForeignURL(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
+// A release with no manifest describes nothing, so nothing can be verified -- and the
+// binaries are there, which is what makes this worth refusing rather than shrugging at.
+func TestFetchRefusesAReleaseWithNoManifest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 1, "tag_name": "shelf", "target_commitish": "abc",
+			"assets": []map[string]any{
+				{"id": 1, "name": "anchord-linux-amd64", "size": 4096, "state": "uploaded"},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
 
-	base := serve(t, files, func(m *Manifest) {
-		m.Binaries[0].URL = "https://example.invalid/anchord-linux-amd64"
-	})
+	t.Setenv(insecureEnv, "1")
 
-	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
+	src := Source{API: srv.URL, Repo: "veil-net/anchor", Tag: "shelf", Token: "t0ken"}
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), manifestName) {
+		t.Fatalf("want a missing-manifest refusal, got %v", err)
+	}
+}
+
+// Half-uploaded assets mean the publish step is still running, or failed part way. Either
+// way the release is not what the manifest claims yet.
+func TestFetchRefusesAnUnfinishedRelease(t *testing.T) {
+	f := newRelease(pair())
+	f.states["anchord-linux-amd64"] = "starter"
+
+	_, src := f.serve(t, testPin, 1)
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "not finished") {
+		t.Fatalf("want an unfinished-release refusal, got %v", err)
+	}
+}
+
+func TestFetchWithoutATokenSaysSo(t *testing.T) {
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 1)
+
+	src.Token = ""
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), TokenEnv) {
+		t.Fatalf("want an error naming %s, got %v", TokenEnv, err)
+	}
+}
+
+// A 404 against a private repository is ambiguous between "no such tag" and "this token
+// cannot see the repository", so the message has to raise both.
+func TestAMissingTagNamesBothCauses(t *testing.T) {
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 1)
+
+	src.Tag = "nope"
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
 	if err == nil {
-		t.Fatal("a per-binary url on another host should be refused")
+		t.Fatal("want a 404 refusal")
 	}
 
-	if !strings.Contains(err.Error(), "example.invalid") {
-		t.Errorf("the error should name the host; it said: %v", err)
+	for _, s := range []string{"nope", "Contents: read", TokenEnv} {
+		if !strings.Contains(err.Error(), s) {
+			t.Errorf("the error does not mention %q: %v", s, err)
+		}
+	}
+}
+
+func TestARefusedTokenSaysSo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(insecureEnv, "1")
+
+	src := Source{API: srv.URL, Repo: "veil-net/anchor", Tag: "shelf", Token: "expired"}
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("want a 401 refusal, got %v", err)
 	}
 }
 
 func TestFetchRefusesPlainHTTPWithoutTheOverride(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
-	base := serve(t, files, nil)
+	f := newRelease(pair())
+	srv, src := f.serve(t, testPin, 1)
 
-	// serve() set the override; take it away again for this one.
+	// serve() sets the override; take it away again, which is the real configuration.
 	t.Setenv(insecureEnv, "")
 
-	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
-	if err == nil {
-		t.Fatal("a plain-http shelf should be refused unless the override is set")
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "plain http") {
+		t.Fatalf("want a scheme refusal, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "plain http") {
-		t.Errorf("the error should say why; it said: %v", err)
-	}
+	_ = srv
 }
 
+// A truncated download is a real binary of nearly the right size, which is the shape
+// neither the size gate in `make dist` nor the header check in anchor's own test would
+// catch. The byte count is checked before the digest so the message says which it was.
 func TestFetchRefusesAShortBody(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("the whole thing")}
+	files := pair()
+	f := newRelease(files)
 
-	base := serve(t, files, func(m *Manifest) { m.Binaries[0].Bytes = 999999 })
+	f.manifestJSON = f.manifest(testPin, 1)
 
-	err := Fetch(context.Background(), base, keys(files), t.TempDir(), quiet)
-	if err == nil {
-		t.Fatal("a body shorter than the manifest promises should be refused")
-	}
+	// Claim more bytes than are served.
+	f.manifestJSON = strings.Replace(f.manifestJSON,
+		fmt.Sprintf(`"bytes":%d`, len(files["anchord-linux-amd64"])),
+		fmt.Sprintf(`"bytes":%d`, len(files["anchord-linux-amd64"])+1), 1)
 
-	if !strings.Contains(err.Error(), "bytes") {
-		t.Errorf("the error should name the length; it said: %v", err)
+	_, src := f.serve(t, testPin, 1)
+
+	err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), quiet)
+	if err == nil || !strings.Contains(err.Error(), "bytes") {
+		t.Fatalf("want a short-body refusal, got %v", err)
 	}
 }
 
-func TestFetchReportsTheRealm(t *testing.T) {
-	files := map[string][]byte{"anchord-linux-amd64": []byte("x")}
-	base := serve(t, files, nil)
+// The realm and the commit are the two lines worth reading on a fetch: they say which
+// tree these binaries will talk to, and which anchor commit produced them.
+func TestFetchReportsTheRealmAndCommit(t *testing.T) {
+	f := newRelease(pair())
+	_, src := f.serve(t, testPin, 1)
 
-	var lines []string
-	log := func(format string, a ...any) { lines = append(lines, fmt.Sprintf(format, a...)) }
+	var out strings.Builder
 
-	if err := Fetch(context.Background(), base, keys(files), t.TempDir(), log); err != nil {
+	log := func(format string, a ...any) { fmt.Fprintf(&out, format+"\n", a...) }
+
+	if err := Fetch(context.Background(), src, []string{"anchord-linux-amd64"}, t.TempDir(), log); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 
-	// The realm these binaries are pinned to decides which tree a conflux built from
-	// them can ever join, so it belongs in front of whoever ran the build.
-	if !strings.Contains(strings.Join(lines, "\n"), "realmtestpin") {
-		t.Errorf("the pin was not reported; the output was:\n%s", strings.Join(lines, "\n"))
+	for _, s := range []string{testPin, f.commit, "veil-net/anchor", "shelf"} {
+		if !strings.Contains(out.String(), s) {
+			t.Errorf("the log does not mention %q:\n%s", s, out.String())
+		}
 	}
 }
 
-func keys(m map[string][]byte) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
+func sha256Of(b []byte) []byte {
+	sum := sha256.Sum256(b)
 
-	return out
+	return sum[:]
 }

--- a/scripts/anchor-bins.sh
+++ b/scripts/anchor-bins.sh
@@ -103,7 +103,7 @@ if [ -z "$src" ] && [ "$FETCH" = 1 ]; then
   if [ -z "${ANCHOR_RELEASE_TOKEN:-}" ]; then
     echo "anchor-bins: ANCHOR_RELEASE_TOKEN is not set, and anchor is a private repository." >&2
     echo "anchor-bins: it needs a GitHub token with Contents: read on veil-net/anchor." >&2
-    echo "anchor-bins: in CI that is the repository secret of the same name; locally, export it." >&2
+    echo "anchor-bins: CI mints one per job from a GitHub App; locally, export your own." >&2
     echo "anchor-bins: see docs/build.md." >&2
     exit 1
   fi

--- a/scripts/anchor-bins.sh
+++ b/scripts/anchor-bins.sh
@@ -7,13 +7,17 @@
 #
 #   make anchor-bins                      from ../anchor
 #   make anchor-bins ANCHOR_SRC=/path     from somewhere else
-#   make anchor-bins FETCH=1              from the published shelf, no checkout needed
+#   make anchor-bins FETCH=1              from anchor's release, needs ANCHOR_RELEASE_TOKEN
 #
 # Three sources, in that order of preference. A local release/ is the pinned build and
 # wins outright. A local dist/ is the unpinned development cross-build and is taken
-# loudly. With neither, FETCH=1 downloads the pinned binaries from the shelf and
-# verifies every digest -- which is what lets CI, and a fresh clone, have the real ones
-# without a checkout and without a credential.
+# loudly. With neither, FETCH=1 downloads the pinned binaries from anchor's `shelf`
+# release and verifies every digest -- which is what lets CI, and a fresh clone, have the
+# real ones without a checkout of anchor.
+#
+# That last one needs a credential, because anchor is private and GitHub has no
+# releases-only read scope. See internal/shelf for why holding that token in a public
+# repository is nonetheless contained.
 #
 # With no source at all it writes placeholders, which is what lets gofmt, vet,
 # staticcheck and the unit tests run on a machine with no access to any of the above. A
@@ -30,7 +34,14 @@ DEST=${DEST:-anchor/bin}
 # would move 284 MB to compile 43. Once the shelf serves every target and the per-target
 # narrowing exists, this default is one line to flip.
 FETCH=${FETCH:-0}
-SHELF_URL=${SHELF_URL:-}
+
+# Where the release lives. Empty means the fetcher's own defaults, so the values are
+# stated once in internal/shelf rather than twice. ANCHOR_API exists so this path can be
+# pointed at a stand-in and actually exercised -- a fetch that is only ever run against
+# the real thing is one nobody can test before shipping it.
+ANCHOR_API=${ANCHOR_API:-}
+ANCHOR_REPO=${ANCHOR_REPO:-}
+ANCHOR_TAG=${ANCHOR_TAG:-}
 
 TARGETS="linux-amd64 linux-arm64 darwin-arm64 windows-amd64 windows-arm64 freebsd-amd64 openbsd-amd64"
 
@@ -84,15 +95,28 @@ EOF
 # a JSON parser to become buildable. The fetcher imports nothing that embeds anything,
 # so it still runs when anchor/bin is empty -- which is the only moment it is wanted.
 if [ -z "$src" ] && [ "$FETCH" = 1 ]; then
-  echo "anchor-bins: no local anchor build; fetching the pinned binaries from the shelf" >&2
+  echo "anchor-bins: no local anchor build; fetching the pinned binaries from anchor's release" >&2
+
+  # Said here rather than left to the fetcher, because this is the one failure whose
+  # remedy is a person setting something up rather than a thing being retried, and it
+  # should not arrive looking like a network error.
+  if [ -z "${ANCHOR_RELEASE_TOKEN:-}" ]; then
+    echo "anchor-bins: ANCHOR_RELEASE_TOKEN is not set, and anchor is a private repository." >&2
+    echo "anchor-bins: it needs a GitHub token with Contents: read on veil-net/anchor." >&2
+    echo "anchor-bins: in CI that is the repository secret of the same name; locally, export it." >&2
+    echo "anchor-bins: see docs/build.md." >&2
+    exit 1
+  fi
 
   args=""
-  [ -n "$SHELF_URL" ] && args="-url $SHELF_URL"
+  [ -n "$ANCHOR_API" ] && args="$args -api $ANCHOR_API"
+  [ -n "$ANCHOR_REPO" ] && args="$args -repo $ANCHOR_REPO"
+  [ -n "$ANCHOR_TAG" ] && args="$args -tag $ANCHOR_TAG"
 
   # $want is the same list the prune above is built from, so there is one definition of
   # what belongs here rather than two that can disagree.
   if go run ./cmd/anchor-fetch $args -dest "$DEST" -want "$(echo $want | tr ' ' ',')"; then
-    echo "anchor-bins: $TOTAL/$TOTAL fetched from the shelf (pinned release build)"
+    echo "anchor-bins: $TOTAL/$TOTAL fetched from anchor's release (pinned build)"
     exit 0
   fi
 


### PR DESCRIPTION
The shelf was an unauthenticated GET against `api.veilnet.com.au`, and its best property was written all over `internal/shelf`: *no credential in either direction*.

That shelf was never populated. It has served **2 of the 14** binaries conflux embeds for as long as it has existed, so every job needing real binaries has been red against a promise nothing was keeping.

anchor publishes a `shelf` release now ([veil-net/anchor#22](https://github.com/veil-net/anchor/pull/22)), so this reads that instead. The honest part of the change is that it needs a token, and the comments say so rather than inheriting the old claim.

## Why a token

anchor is private, and **GitHub has no releases-only read scope** — releases live under `Contents`, the same permission that grants the source. So the key that reads two binaries also opens the front door, and there is no narrower one to ask for.

Why that is acceptable, stated once in `internal/shelf` so it is not re-derived later: GitHub never passes secrets to workflows triggered by **fork** pull requests, and conflux's Linux jobs refuse fork pull requests outright. The token is not reachable by anyone who does not already have write access to this repository.

## What replaced the same-host rule is stronger

The old rule existed because a document conflux had just downloaded was deciding where conflux would fetch from next. Nothing reads a URL out of a document now: every request is built from this package's own constants — one API host, one repository, one tag — and binaries are resolved by asset **name** within that single release. The set of places a fetch can reach is fixed by conflux's configuration rather than by anything on the wire.

The cross-host redirect refusal had to go, because an asset download answers with one to storage. Two things make that safe, and both are asserted rather than assumed: Go drops the `Authorization` header on a redirect to another host, so the token never reaches the storage host, and the digest is still checked against a manifest fetched from the API. A downgrade to plain `http` is still refused.

## Two traps worth naming

**`secrets: inherit`.** `release.yml` calls `ci.yml`, and a called workflow gets *no* secrets by default. Without that line every `anchor-bins` step inside it would fail on a token that is set in one file and empty in the other — and the only sign of the difference is that nothing works.

**The token goes through the environment, never as an argument.** An argument is visible in `ps` to every other user on the machine, and these jobs run on a machine that is not destroyed at the end of them.

## Error messages

A 404 against a private repository means *either* "no such tag" *or* "this token cannot see the repository", and GitHub reports them identically — so the message raises both rather than being the least informative true statement available. A 401 names expiry, which is how this will actually fail one day.

## Verification

**Seventeen tests**, over a stand-in serving the GitHub release shape rather than what this package happens to need. Four were checked by *breaking the code they cover* — the `Authorization` header, the `anchoradmin` refusal, and the digest compare with its leave-nothing-behind companion. A test that cannot fail is worse than no test, and this repository has been caught by exactly that before.

End to end against anchor's real publish script over a stand-in API: 14 binaries and a manifest uploaded, then fetched back **byte-identical** with every digest verified and executable bits intact; `anchoradmin` refused from both directions independently; wrong token → 401 with the expiry hint; missing tag → the two-cause message; no token → setup instructions.

Locally green: `gofmt`, `go vet`, `go mod tidy -diff`, full `go test ./...`, `make cross` (all seven targets).

## Before this can go green

Two things, in order:

1. **[veil-net/anchor#22](https://github.com/veil-net/anchor/pull/22) merges and its `release` job runs**, creating the `shelf` release. Until that exists there is nothing to fetch.
2. **`ANCHOR_RELEASE_TOKEN` is added** as a repository secret here — a fine-grained token, resource owner `veil-net`, repository access limited to `veil-net/anchor`, permission **Contents: Read-only**. A Secret, not a Variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WycftHLnK63RCNsVUh3Kg

---
_Generated by [Claude Code](https://claude.ai/code/session_012WycftHLnK63RCNsVUh3Kg)_