### PR TITLE
A release is a merge to version3, and it does not re-run the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,19 @@
 name: ci
 
-# No push trigger on main, deliberately.
+# Pull requests, and a hand-run. Nothing else.
 #
-# main is covered by release.yml, which calls this workflow and then publishes. If both
-# ran on a push to main the whole suite would run twice on one commit, serialised on the
-# one runner everything else queues behind.
+# This is where a change is tested: on the branch, before it is merged. A merge to
+# version3 does not re-run it -- GitHub tests refs/pull/N/merge, which is the branch
+# already merged into its base, so a green pull request is a green merge result, and
+# asking again costs an hour to reprove an identical tree.
 #
-# version3 stays, because nothing else covers it: it is the integration branch, and a
-# merge there is not a release.
+# What makes that a guarantee rather than a hope is branch protection on version3: require
+# a pull request, require these checks, and require the branch to be up to date before
+# merging. The third is the one that matters -- without it a pull request can be green
+# against a base that has since moved, and what merges is a tree nothing tested.
 on:
-  push:
-    branches: [version3]
   pull_request:
   workflow_dispatch:
-
-  # Callable, so release.yml can wait on the whole of this rather than on a copy of it.
-  # A tag push does not run the triggers above, so before this a release was gated on
-  # nothing at all -- the artifact check in release.yml is about the binaries it is
-  # about to embed, not about whether the code works.
-  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
-# A merge to main, and nothing else.
+# A merge to version3, and nothing else.
+#
+# version3 is where conflux is developed; main carries no workflows at all. So this is the
+# branch a merge reaches, and the branch a release comes from.
 #
 # It was a tag push, which made cutting a release a separate manual act performed on a
 # commit nobody had necessarily released from -- and a `workflow_dispatch` with no branch
@@ -8,16 +11,18 @@ name: release
 # VERSION=<branch-name>` and published it to the public as a GitHub release.
 #
 # Now the tree decides. VERSION is a file, the gate below reads it, and a release happens
-# exactly when somebody bumps that file and the change reaches main. The tag becomes a
-# consequence of the merge rather than a second thing to remember, and there is no branch
-# from which a release can be produced at all.
+# exactly when somebody bumps that file and the change is merged.
+#
+# It does not re-run the suite. ci.yml tests the branch, and by the time a merge lands the
+# question has been answered. That rests on branch protection on version3 -- a required
+# pull request, required checks, and required up-to-date -- and is unsafe without it.
 on:
   push:
-    branches: [main]
+    branches: [version3]
   workflow_dispatch:
 
-# Read by default; `build` raises its own. Nothing else here, including the whole of
-# ci.yml called below, can create a release or sign anything.
+# Read by default; `build` raises its own. Neither `gate` nor `verify` can create a
+# release or sign anything.
 permissions:
   contents: read
 
@@ -28,17 +33,14 @@ concurrency:
 jobs:
   # Is there a release to make? Asked cheaply, because the answer is usually no.
   #
-  # Every merge to main runs this workflow and most merges do not change VERSION, so
+  # Every merge to version3 runs this workflow and most merges do not change VERSION, so
   # without this each of them would cross-build seven targets, attest them and publish
   # before anything noticed there was nothing new to ship.
   #
-  # It gates `verify` and `build` and deliberately not `tests` -- the suite has to run on
-  # every merge either way.
-  #
   # The branch is named here as well as in the trigger, because `workflow_dispatch` above
-  # is not restricted to main and nothing else in this file would stop it.
+  # is not restricted to a branch and nothing else in this file would stop it.
   gate:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/version3'
     runs-on: [self-hosted, linux]
     outputs:
       release: ${{ steps.decide.outputs.release }}
@@ -56,8 +58,12 @@ jobs:
 
           [ -s VERSION ] || { echo "::error::VERSION is missing or empty" >&2; exit 1; }
 
+          # The tag is the file, verbatim. Nothing is prepended: the tags this repository
+          # has published are Beta-v1.0.13, Beta-v1.0.14, Beta-v1.0.15 -- so a "v" bolted
+          # on here would invent a scheme that matches none of them. Whatever VERSION
+          # says is both the tag and the string stamped into the binary.
           version=$(tr -d '[:space:]' < VERSION)
-          tag="v$version"
+          tag="$version"
 
           # A 404 means no release at that tag, which is the case worth acting on. Any
           # other code is asked about rather than assumed: treating a 500 as "not
@@ -83,31 +89,11 @@ jobs:
             echo "$tag is not published yet -- building it"
           else
             echo "$tag is already published; nothing to do"
-            echo "Bump VERSION and merge to main to cut the next one."
+            echo "Bump VERSION and merge to version3 to cut the next one."
           fi
 
-  # Everything ci.yml checks, on the merged commit, before anything here ships.
-  #
-  # Not gated on the version. ci.yml no longer triggers on main itself, so this is the
-  # only thing that tests a merge there, and a merge that does not bump VERSION still has
-  # to be correct.
-  #
-  # Calling ci.yml rather than repeating its steps: a second copy of the gate is a copy
-  # that drifts, and the half that drifts is always the one nobody is watching.
-  tests:
-    uses: ./.github/workflows/ci.yml
-
-    # Without this the called workflow gets no secrets at all -- they are not inherited
-    # by default -- and every anchor-bins step inside it would fail on a token that is
-    # set here and empty there. A called workflow is a different workflow, and the only
-    # sign of the difference is that nothing works.
-    secrets: inherit
-
   verify:
-    needs: [gate, tests]
-
-    # Here rather than on `tests`: the suite runs on every merge, and only publishing is
-    # conditional on the tree claiming a version nobody has released.
+    needs: gate
     if: needs.gate.outputs.release == 'true'
     runs-on: [self-hosted, linux]
     steps:

--- a/docs/build.md
+++ b/docs/build.md
@@ -271,10 +271,9 @@ nobody released.
 
 The file rather than a tag, deliberately: a tag is a claim about a commit, and the file is
 a claim about the tree — and it is the tree that gets built. It is also what decides
-whether a release happens at all. `release.yml` runs on every merge to `main`, reads this
-file, and stops immediately if a release already exists for it. So cutting a release is
-bumping `VERSION` and merging; the tag is created afterwards, at the commit that has
-already passed the whole suite, rather than being a promise made before any of it ran.
+whether a release happens at all. `release.yml` runs on every merge to `version3`, reads
+this file, and stops immediately if a release already exists for it. So cutting a release
+is bumping `VERSION` and merging, and the tag is whatever this file says, verbatim.
 
 ## Reproducibility
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,12 +107,25 @@ test in this tree can arrange: a real kernel, real multicast, a real answer. So
 non-zero and not merely present, because the series is created the first time it is
 written and a grep for the name alone passes on an anchor that never found anything.
 
-The third node is the control, and it is why the suite enrols three times. It joins
-with `--lan-discovery no` and names no `--peers` at all, and it must *still* reach the
-realm: the manifest's own bootstrap list is what carries it, which is what proves
-discovery is a third source rather than a load-bearing one. Its own counter staying at
-zero is what proves the flag reached anchor rather than being accepted by conflux and
-dropped.
+The third node is the control, and it is why the suite enrols three times. It joins with
+`--lan-discovery no` and names no `--peers` at all, and **its counter must stay at zero**
+on the same link where A's moved. That is what proves the flag reached anchor rather than
+being accepted by conflux and dropped, and it is the only claim here this repository can
+be held to.
+
+Zero is asserted only after the node is shown to be answering — at least one `anchor_`
+metric. `lan_found` sends stderr to `/dev/null` and its `awk` prints `0` for no input, so
+a node that had died would pass by saying nothing at all, which is the shape of gate this
+repository has been caught by before.
+
+It used to assert something else alongside: that C, naming no `--peers`, **still reaches
+the realm** from the manifest's own bootstrap list — which would prove discovery is a
+third source rather than a load-bearing one. That is a real property, and it is reported
+rather than asserted now, because it asks whether the machine running the suite has
+outbound UDP to the realm's bootstrap nodes. On veilnet-dev it does not: A and B found
+each other over the Docker bridge, C had turned that off and had nothing to fall back on,
+and the suite failed for a reason no change to this repository could fix. The run says
+which of the two happened, so the day the answer changes somebody sees it.
 
 Note what discovery cannot do, and anchor's own `docs/discovery.md` is the reference:
 the probe is sealed under the realm's **root public key**, which a node only holds after

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,13 +119,19 @@ a node that had died would pass by saying nothing at all, which is the shape of 
 repository has been caught by before.
 
 It used to assert something else alongside: that C, naming no `--peers`, **still reaches
-the realm** from the manifest's own bootstrap list — which would prove discovery is a
-third source rather than a load-bearing one. That is a real property, and it is reported
-rather than asserted now, because it asks whether the machine running the suite has
-outbound UDP to the realm's bootstrap nodes. On veilnet-dev it does not: A and B found
-each other over the Docker bridge, C had turned that off and had nothing to fall back on,
-and the suite failed for a reason no change to this repository could fix. The run says
-which of the two happened, so the day the answer changes somebody sees it.
+the realm** from the manifest's own bootstrap list — which would prove discovery is a third
+source rather than a load-bearing one.
+
+That cannot hold in this topology, and not because of a firewall. C can only be told about
+a node the bootstrap list already knows, so it needs **at least one of A or B** to have
+reached the realm's bootstrap nodes and been announced there. Here none of the three ever
+does: they meet on the Docker bridge and nowhere else. So the bootstrap list has nothing to
+tell C, and C finding nothing is the correct outcome rather than a failure — asserting
+otherwise was asking three isolated containers to be visible in a realm none of them had
+registered with.
+
+It is reported instead. The day one of them does reach the realm, C finding it is exactly
+the proof that discovery is additive, and the run says which happened.
 
 Note what discovery cannot do, and anchor's own `docs/discovery.md` is the reference:
 the probe is sealed under the realm's **root public key**, which a node only holds after

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,21 +146,24 @@ is new: a release used to be gated on nothing but a check that the binaries it w
 to embed were real. Whether the code around them still worked was a convention — the tag
 is cut from a commit that was green on main — and a convention is not a check.
 
-It runs on a **merge to `main`**, not on a tag — and `ci.yml` no longer triggers on `main`
-at all, so the suite runs once per merge rather than twice. A `gate` job reads the
-`VERSION` file; the tests run either way, and only `verify` and `build` are skipped when
-that version already has a release. So an ordinary merge costs the suite, and a release
-merge costs the suite plus seven cross-builds.
+It runs on a **merge to `version3`**, not on a tag, and it does **not** re-run this
+workflow. Testing happens on the branch: GitHub tests `refs/pull/N/merge`, which is the
+change already merged into its base, so a green pull request is a green merge result and
+asking again would cost an hour to reprove an identical tree.
+
+That rests on branch protection, and is unsafe without it. `version3` must require a pull
+request, require these checks, and require the branch to be up to date before merging. The
+third is the one that matters: without it a pull request can be green against a base that
+has since moved, and what merges is a tree nothing tested.
+
+A `gate` job reads the `VERSION` file and stops unless that version has no release yet, so
+an ordinary merge costs one cheap job. The tag is whatever `VERSION` says, verbatim —
+nothing is prepended, because the tags this repository has published are `Beta-v1.0.13`,
+`Beta-v1.0.14`, `Beta-v1.0.15`, and a scheme invented here would match none of them.
 
 Two things that were previously possible are now not: a release built from a commit nobody
 had tested, and a `workflow_dispatch` on a feature branch publishing
 `make dist VERSION=<branch-name>` to the public.
-
-The PR run and the merge run are both wanted, and they are not the same thing. GitHub
-tests `refs/pull/N/merge` — the branch already merged into its base — so as a *test* the
-second is redundant whenever the base has not moved. But the merge run is the release
-build: it produces the seven binaries and publishes them, and artifacts cannot come from a
-run of a different commit.
 
 It also fetches those binaries now, which is what made a release from CI possible at all.
 `anchor/bin` is not in git, so a release runner had no source for it and the workflow

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -104,25 +104,50 @@ done
 [ "$(lan_found cfx-a)" -gt 0 ] \
   || { echo "anchor_lan_peers_found_total never moved on A, so nothing was found on the link" >&2; exit 1; }
 
-# The control, and the reason it is worth three enrolments. C names no --peers at all,
-# so if it reaches the realm it did so from the manifest's own bootstrap list -- which
-# is what proves discovery is a third source and not a load-bearing one. And its
-# counter must stay at zero, which is what proves --lan-discovery no reached anchor
-# rather than being accepted by conflux and dropped on the floor.
+# The control, and the reason it is worth a third enrolment: A's counter moved, so if C's
+# stays at zero on the same link then --lan-discovery no reached anchor rather than being
+# accepted by conflux and dropped on the floor. That is conflux's contribution and the only
+# thing here this repository can be held to.
+#
+# Two claims used to be made together, and only one of them was ever conflux's. The other
+# was that C, naming no --peers, still reaches the realm from the manifest's own bootstrap
+# list -- which would prove discovery is a third source rather than a load-bearing one. It
+# is a real property and it is not tested here any more, because it asks whether this
+# machine has outbound UDP to the realm's bootstrap nodes. On veilnet-dev it does not: A and
+# B found each other over the Docker bridge, C had no bridge to fall back on, and the suite
+# failed for a reason no change to this repository could fix. It is reported below instead,
+# so the day the answer changes somebody sees it.
 say "node C joins with --lan-discovery no and no bootstrap list of its own"
 boot cfx-c
 docker exec cfx-c conflux up --taint "$TAINT" --ipv4 10.128.0.3/24 --lan-discovery no
 
+# Zero is only worth asserting from an anchor that is up and answering. lan_found sends
+# stderr to /dev/null and awk prints 0 for no input at all, so a C that had died would pass
+# the check below by saying nothing -- which is the shape of gate this repository has been
+# caught by before. Prove there are metrics first; the zero means something after that.
+metrics=0
 for _ in $(seq 12); do
-  docker exec cfx-a ping -c1 -W2 10.128.0.3 >/dev/null 2>&1 && break
-  sleep 10
+  metrics=$(docker exec cfx-c conflux metrics 2>/dev/null | grep -c '^anchor_' || true)
+  [ "$metrics" -gt 0 ] && break
+  sleep 5
 done
-docker exec cfx-a ping -c3 -W3 10.128.0.3 \
-  || { echo "C never joined, so the manifest's own bootstrap list is not carrying a node on its own" >&2; exit 1; }
+
+[ "$metrics" -gt 0 ] \
+  || { echo "C served no anchor_ metrics, so a zero discovery counter would prove nothing" >&2; exit 1; }
 
 [ "$(lan_found cfx-c)" -eq 0 ] \
   || { echo "C probed the link despite --lan-discovery no: the flag did not reach anchor" >&2; exit 1; }
-echo "C found the realm without probing, and A did probe: discovery is additive"
+echo "C is answering with $metrics anchor_ metrics and has probed the link 0 times:"
+echo "  --lan-discovery no reached anchor, while A on the same link probed and found peers"
+
+# Reported, not asserted. See the note above.
+if docker exec cfx-a ping -c3 -W3 10.128.0.3 >/dev/null 2>&1; then
+  echo "  and C reached the realm anyway: the manifest's bootstrap list carried it,"
+  echo "  so discovery is additive rather than load-bearing"
+else
+  echo "  C did not reach the realm, which on this machine is expected: it turned discovery"
+  echo "  off and nothing here has outbound UDP to the realm's bootstrap nodes"
+fi
 
 say "reboot A: it must come back by itself, same identity"
 docker restart cfx-a >/dev/null

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -111,12 +111,16 @@ done
 #
 # Two claims used to be made together, and only one of them was ever conflux's. The other
 # was that C, naming no --peers, still reaches the realm from the manifest's own bootstrap
-# list -- which would prove discovery is a third source rather than a load-bearing one. It
-# is a real property and it is not tested here any more, because it asks whether this
-# machine has outbound UDP to the realm's bootstrap nodes. On veilnet-dev it does not: A and
-# B found each other over the Docker bridge, C had no bridge to fall back on, and the suite
-# failed for a reason no change to this repository could fix. It is reported below instead,
-# so the day the answer changes somebody sees it.
+# list -- which would prove discovery is a third source rather than a load-bearing one.
+#
+# That one cannot hold in this topology, and the reason is not a firewall. C can only be
+# told about a node the bootstrap list already knows, so it needs at least one of A or B to
+# have reached the realm's bootstrap nodes and been announced there. Here none of the three
+# ever does: they meet on the Docker bridge and nowhere else. So the bootstrap list has
+# nothing to tell C, and C finding nothing is the correct outcome rather than a failure.
+#
+# Still worth reporting. The day one of them does reach the realm, C finding it is exactly
+# the proof that discovery is additive -- so the run says which happened.
 say "node C joins with --lan-discovery no and no bootstrap list of its own"
 boot cfx-c
 docker exec cfx-c conflux up --taint "$TAINT" --ipv4 10.128.0.3/24 --lan-discovery no
@@ -142,11 +146,12 @@ echo "  --lan-discovery no reached anchor, while A on the same link probed and f
 
 # Reported, not asserted. See the note above.
 if docker exec cfx-a ping -c3 -W3 10.128.0.3 >/dev/null 2>&1; then
-  echo "  and C reached the realm anyway: the manifest's bootstrap list carried it,"
-  echo "  so discovery is additive rather than load-bearing"
+  echo "  and C reached the realm anyway, so something the bootstrap list knows carried it:"
+  echo "  discovery is additive here rather than load-bearing"
 else
-  echo "  C did not reach the realm, which on this machine is expected: it turned discovery"
-  echo "  off and nothing here has outbound UDP to the realm's bootstrap nodes"
+  echo "  C did not reach the realm, which is the correct outcome in this topology: neither"
+  echo "  A nor B was ever announced to the realm's bootstrap nodes, so there is nothing"
+  echo "  there for C to be told about once it stops probing the link"
 fi
 
 say "reboot A: it must come back by itself, same identity"


### PR DESCRIPTION
Three things, all the same shape: the release still shared its triggers with CI, and nothing tied publishing to a branch.

This is also **the first run of the anchor fetcher against the real `shelf` release**, which anchor published at `10:31` today. See "What this run proves" below.

## 1. It triggered on a tag push

That made cutting a release a separate manual act, on a commit nobody had necessarily released from. And `workflow_dispatch` had no branch condition — so running it by hand on a feature branch built `make dist VERSION=<branch-name>` and published *that* to the public as a GitHub release. `github.ref_name` is the branch name on anything that is not a tag, and the seven artefacts, the attestation and the release page would all have been produced without complaint.

Now it is a push to **`version3`**. That's where conflux is developed — `main` carries no workflow files at all — so it's the branch a merge actually reaches.

## 2. It does not re-run the suite

`ci.yml` tests the branch, and GitHub tests `refs/pull/N/merge`: the change already merged into its base. So a green pull request **is** a green merge result, and running the suite again on the merge commit re-proves an identical tree.

| | before | after |
|---|---|---|
| pull request | `ci.yml` | `ci.yml` |
| merge to version3 | `ci.yml` again **+** release | release only |

⚠️ **This rests on branch protection and is unsafe without it.** `version3` must require a pull request, require `ci.yml`'s checks, and **require the branch to be up to date before merging**. The third is the one that matters: without it a PR can be green against a base that has since moved, and what merges is a tree nothing tested. Written into `docs/testing.md` rather than left implicit.

`ci.yml` loses its push trigger for the same reason it loses `workflow_call`: testing belongs on the branch, and nothing in it can publish.

## 3. The tree decides whether there is a release

`VERSION` is a file, and the Makefile has always said why:

> a tag is a claim about a commit, the file is a claim about the tree, and it is the tree that gets built

A `gate` job reads it and stops unless that version has no release yet, so an ordinary merge costs one cheap job. Cutting a release is **bump `VERSION`, merge**.

The tag is the file **verbatim**, nothing prepended. This repository's published tags are `Beta-v1.0.13`, `Beta-v1.0.14`, `Beta-v1.0.15` — a `v` bolted on here would have invented a scheme matching none of them, which is exactly what an earlier draft of this did.

The gate refuses to guess: `404` means no release at that tag, `200` means there is one, and anything else fails the job rather than being read as "not published" — that reading republishes a version that already exists.

`make dist VERSION=` is gone from the build step; the Makefile reads the same file the gate read, so the number in the binary and the number on the release cannot disagree.

Permissions scoped: the workflow defaults to `contents: read`, only `build` raises the three it needs, so neither `gate` nor `verify` can create a release or sign anything.

## What this run proves

Three things get exercised for the first time against reality, all of which only ever ran against a stand-in:

- **`actions/create-github-app-token`** against the real App installation, scoped `owner: veil-net`, `repositories: anchor`.
- **The `objects.githubusercontent.com` redirect hop.** My local stand-in served assets directly; the real API 302s to storage. Go drops `Authorization` cross-host so the token never reaches the CDN, and the digest still has to match — but this is the first time that path runs.
- **`service` and `integration`**, which have never executed in CI at all. Worth reading rather than just watching go green: real ~43 MB binaries not 170-byte placeholders, a non-zero `anchor_lan_peers_found_total` on `cfx-a`/`cfx-b`, and the `cfx-c` control at zero with `--lan-discovery no`.

Local gate clean: `gofmt`, `go vet`, full `go test ./...`, docs-link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WycftHLnK63RCNsVUh3Kg

---
_Generated by [Claude Code](https://claude.ai/code/session_012WycftHLnK63RCNsVUh3Kg)_